### PR TITLE
docs: fix logo path

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -2,8 +2,8 @@
   "title": "@nuxtjs/sanity",
   "url": "https://sanity.nuxtjs.org",
   "logo": {
-    "dark": "sanity-dark.svg",
-    "light": "sanity-light.svg"
+    "dark": "/sanity-dark.svg",
+    "light": "/sanity-light.svg"
   },
   "github": "nuxt-community/sanity-module"
 }


### PR DESCRIPTION
The logo is broken when you want to go directly to a subpage.

Example: https://sanity.nuxtjs.org/quick-start/