### PR TITLE
docs: add example with `@sanity/image-url`

### DIFF
--- a/docs/content/en/helpers/images.md
+++ b/docs/content/en/helpers/images.md
@@ -83,6 +83,32 @@ If you pass in a default scopedSlot you can use the `<SanityImage>` component as
 </template>
 ```
 
-## Other resources
+## Using @sanity/image-url
 
-If you are procedurally generating your image URLs you may wish to use [the `@sanity/image-url` package](https://github.com/sanity-io/image-url).
+If the `SanityContent` helper doesn't cover your needs, you can use [the `@sanity/image-url` package](https://github.com/sanity-io/image-url). One way to add it to your Nuxt project is through a plugin:
+
+```js{}[plugins/sanity-image-builder.js]
+import imageUrlBuilder from '@sanity/image-url'
+
+export default ({ $sanity }, inject) => {
+  const builder = imageUrlBuilder($sanity.config)
+  function urlFor(source) {
+    return builder.image(source).auto('format')
+  }
+  inject('urlFor', urlFor)
+}
+```
+
+Then you can use the global `$urlFor` helper:
+
+```vue
+<template>
+  <img
+    :src="$urlFor(movie.image).size(426)"
+    :alt="movie.title"
+    height="426"
+    width="426"
+    loading="lazy"
+  />
+</template>
+```

--- a/docs/content/en/helpers/images.md
+++ b/docs/content/en/helpers/images.md
@@ -85,7 +85,7 @@ If you pass in a default scopedSlot you can use the `<SanityImage>` component as
 
 ## Using @sanity/image-url
 
-If the `SanityContent` helper doesn't cover your needs, you can use [the `@sanity/image-url` package](https://github.com/sanity-io/image-url). One way to add it to your Nuxt project is through a plugin:
+If the `SanityImage` helper doesn't cover your needs, you can use [the `@sanity/image-url` package](https://github.com/sanity-io/image-url). One way to add it to your Nuxt project is through a plugin:
 
 ```js{}[plugins/sanity-image-builder.js]
 import imageUrlBuilder from '@sanity/image-url'

--- a/docs/content/en/helpers/images.md
+++ b/docs/content/en/helpers/images.md
@@ -3,7 +3,7 @@ title: Image formatting
 description: 'Access text, images, and other media with Nuxt and the Sanity headless CMS.'
 category: Helpers
 position: 11
-version: 0.33
+version: 0.34
 ---
 
 ## Global helper


### PR DESCRIPTION
A small PR. closes #20

maybe we could also add a short paragraph about the cases someone would use `@sanity/client` over `SanityImage`. I haven't really use `SanityImage` yet, but I'm planning to so for an upcoming project, so I'll have more to say about this.

In the example, I thought I might as well show some best practices (alt text, [setting width and height](https://www.youtube.com/watch?v=4-d_SoCHeWE&feature=youtu.be), lazy loading) 😋