### PR TITLE
fix: correctly use `q` prop in `<SanityImage>`

### DIFF
--- a/src/components/sanity-image.ts
+++ b/src/components/sanity-image.ts
@@ -195,6 +195,7 @@ export const SanityImage = extendVue({
       'minH',
       'minW',
       'or',
+      'q',
       'rect',
       'sat',
       'sharpen',


### PR DESCRIPTION
I was trying to change quality of image, but `q` was missing on keys map.