### PR TITLE
docs: add asyncData `fetch` example

### DIFF
--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -3,7 +3,7 @@ title: Usage
 description: 'Access text, images, and other media with Nuxt and the Sanity headless CMS.'
 category: Getting started
 position: 4
-version: 0.40
+version: 0.39
 ---
 
 This module globally injects a `$sanity` helper, meaning that you can access it anywhere using `this.$sanity`. For plugins, asyncData, fetch, nuxtServerInit and middleware, you can access it from `context.$sanity`.

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -3,16 +3,73 @@ title: Usage
 description: 'Access text, images, and other media with Nuxt and the Sanity headless CMS.'
 category: Getting started
 position: 4
-version: 0.39
+version: 0.40
 ---
 
 This module globally injects a `$sanity` helper, meaning that you can access it anywhere using `this.$sanity`. For plugins, asyncData, fetch, nuxtServerInit and middleware, you can access it from `context.$sanity`.
 
 ## Reference
 
-### `fetch`
+### Example with `asyncData`
 
-This enables you to perform a GROQ query against your Sanity dataset. By default it returns a `Promise<unknown>` although you can customise the type of the return.
+<code-group>
+  <code-block label="JavaScript" active>
+
+```js
+import { groq } from '@nuxtjs/sanity'
+
+const query = groq`{ "articles": *[_type == "article"]}`
+
+export default {
+  asyncData({ $sanity }) {
+    return $sanity.fetch(query)
+  },
+}
+```
+
+  </code-block>
+  <code-block label="TypeScript">
+
+```ts
+import { groq } from '@nuxtjs/sanity'
+
+const query = groq`{ "articles": *[_type == "article"]}`
+
+export default {
+  asyncData({ $sanity }) {
+    // By default it returns a `Promise<unknown>`,
+    // but you can customise the type of the return.
+    return $sanity.fetch<string>(query)
+  },
+}
+```
+
+  </code-block>
+</code-group>
+
+<alert type="info">By wrapping the GROQ query into an object, you can return the promise directly. The data will be available in your component under the key used in the query.</alert>
+
+### Example with `fetch`
+
+<code-group>
+  <code-block label="JavaScript" active>
+
+```js
+import { groq } from '@nuxtjs/sanity'
+
+const query = groq`*[_type == "article"][0].title`
+
+export default {
+  async fetch() {
+    const result = await this.$sanity.fetch(query)
+    this.title = result
+  },
+  data: () => ({ title: '' }),
+}
+```
+
+  </code-block>
+  <code-block label="TypeScript">
 
 ```ts
 import { groq } from '@nuxtjs/sanity'
@@ -21,16 +78,15 @@ const query = groq`*[_type == "article"][0].title`
 
 export default {
   async fetch() {
-    // TypeScript (with a typed response)
     const result = await this.$sanity.fetch<string>(query)
-
-    // JavaScript
-    const result = await this.$sanity.fetch(query)
     this.title = result
   },
   data: () => ({ title: '' }),
 }
 ```
+
+  </code-block>
+</code-group>
 
 ### `client`
 

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -22,7 +22,7 @@ This enables you to perform a GROQ query against your Sanity dataset.
 ```js
 import { groq } from '@nuxtjs/sanity'
 
-const query = groq`{ "articles": *[_type == "article"]}`
+const query = groq`{ "articles": *[_type == "article"] }`
 
 export default {
   asyncData({ $sanity }) {
@@ -37,7 +37,7 @@ export default {
 ```ts
 import { groq } from '@nuxtjs/sanity'
 
-const query = groq`{ "articles": *[_type == "article"]}`
+const query = groq`{ "articles": *[_type == "article"] }`
 
 export default {
   asyncData({ $sanity }) {

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -12,7 +12,7 @@ This module globally injects a `$sanity` helper, meaning that you can access it 
 
 ### `fetch`
 
-This enables you to perform a GROQ query against your Sanity dataset.
+This enables you to perform a GROQ query against your Sanity dataset. By default it returns a `Promise<unknown>` although you can customise the type of the return.
 
 #### Example with `asyncData`
 
@@ -43,7 +43,7 @@ export default {
   asyncData({ $sanity }) {
     // By default it returns a `Promise<unknown>`,
     // but you can customise the type of the return.
-    return $sanity.fetch<string>(query)
+    return $sanity.fetch<{ articles: Article[] }>(query)
   },
 }
 ```

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -10,7 +10,11 @@ This module globally injects a `$sanity` helper, meaning that you can access it 
 
 ## Reference
 
-### Example with `asyncData`
+### fetch
+
+This enables you to perform a GROQ query against your Sanity dataset.
+
+#### Example with `asyncData`
 
 <code-group>
   <code-block label="JavaScript" active>
@@ -49,7 +53,7 @@ export default {
 
 <alert type="info">By wrapping the GROQ query into an object, you can return the promise directly. The data will be available in your component under the key used in the query.</alert>
 
-### Example with `fetch`
+#### Example with `fetch`
 
 <code-group>
   <code-block label="JavaScript" active>
@@ -61,8 +65,7 @@ const query = groq`*[_type == "article"][0].title`
 
 export default {
   async fetch() {
-    const result = await this.$sanity.fetch(query)
-    this.title = result
+    this.title = await this.$sanity.fetch(query)
   },
   data: () => ({ title: '' }),
 }
@@ -78,8 +81,9 @@ const query = groq`*[_type == "article"][0].title`
 
 export default {
   async fetch() {
-    const result = await this.$sanity.fetch<string>(query)
-    this.title = result
+    // By default it returns a `Promise<unknown>`,
+    // but you can customise the type of the return.
+    this.title = await this.$sanity.fetch<string>(query)
   },
   data: () => ({ title: '' }),
 }


### PR DESCRIPTION
Hey again!
I added an example of fetching data inside the `asyncData` hook, using a ["shorthand" pattern](https://deploy-preview-60--nuxt-sanity-module.netlify.app/usage#example-with-asyncdata). @vicbergquist used it [in her documentation](https://nuxt-sanity.netlify.app/usage/#in-asyncdata) and I liked how concise the code was. No need for `async/await` keywords or `then()` methods.

Showing both JS and TS variants at the same time ruined a bit the concision that I wanted to showcase. That's why I used the code-block component.