### PR TITLE
docs: add back link to GitHub in header

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -5,5 +5,9 @@
     "dark": "/sanity-dark.svg",
     "light": "/sanity-light.svg"
   },
-  "github": "nuxt-community/sanity-module"
+  "github": {
+    "repo": "nuxt-community/sanity-module",
+    "branch": "main",
+    "dir": "docs"
+  }
 }


### PR DESCRIPTION
closes #91 
also fixes the "edit this page" link.

It took me a moment to find the configuration (https://docus.dev/get-started/configuration) and some more time to realize that `Docus` has yet to be announced 😆