### PR TITLE
Fix broken code block

### DIFF
--- a/docs/pages/en/1.getting-started/3.usage.md
+++ b/docs/pages/en/1.getting-started/3.usage.md
@@ -70,8 +70,8 @@ export default {
 }
 ```
 
-  </d-code-block>
-  <d-code-block label="TypeScript">
+::::
+::::code-block{label="TypeScript"}
 
 ```ts
 import { groq } from '@nuxtjs/sanity'


### PR DESCRIPTION
Teeny tiny change to fix an issue that was causing one of the Usage code blocks to render incorrectly. Probably caused by copy/pasting code after a redesign or something similar.

- broken: https://sanity.nuxtjs.org/getting-started/usage#example-with-fetch
- fixed: https://deploy-preview-180--nuxt-sanity-module.netlify.app/getting-started/usage#example-with-fetch