### PR TITLE
feat: updated default apiVersion

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -72,7 +72,7 @@ export default defineNuxtModule<SanityModuleOptions>(nuxt => ({
     contentHelper: true,
     imageHelper: true,
     dataset: 'production',
-    apiVersion: '1',
+    apiVersion: `${new Date().toISOString().split('T')[0]}`,
     withCredentials: false,
     additionalClients: {},
     ...getDefaultSanityConfig(resolve(nuxt.options.rootDir, './sanity.json')),


### PR DESCRIPTION
Sanity uses ISO dates (YYYY-MM-DD) in UTC timezone for versioning. This PR dynamically assigns the latest and greatest version by default. To override this default, pass in a specific `apiVersion` in to `nuxt.config.js`.

Learn more about Sanity's versioning here:
https://www.sanity.io/docs/api-versioning