### PR TITLE
chore: Fix DEP0148 warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
       "require": "./dist/module.js",
       "import": "./dist/module.es.js"
     },
-    "./": "./",
     "./*": "./*",
     "./sanity-content": "./dist/components/sanity-content.js",
     "./sanity-file": "./dist/components/sanity-file.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "import": "./dist/module.es.js"
     },
     "./": "./",
+    "./*": "./*",
     "./sanity-content": "./dist/components/sanity-content.js",
     "./sanity-file": "./dist/components/sanity-file.js",
     "./sanity-image": "./dist/components/sanity-image.js"


### PR DESCRIPTION
ERROR  (node:69269) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /Volumes/Dane/Repozytoria/osklad.pl/node_modules/@nuxtjs/sanity/package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)

Node: v16.11.1
NPM: 8.0.0

It is compatible with Node v12 as this state: https://github.com/postcss/postcss/issues/1455#issuecomment-722502548