### PR TITLE
fix: add sanity options from runtimeconfig to module defaults

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -79,6 +79,7 @@ export default defineNuxtModule<SanityModuleOptions>({
     withCredentials: false,
     additionalClients: {},
     ...getDefaultSanityConfig(resolve(nuxt.options.rootDir, './sanity.json')),
+    ...nuxt.options.publicRuntimeConfig.sanity
   }),
   async setup (options, nuxt) {
     if (!('useCdn' in options)) {


### PR DESCRIPTION
In the [docs ](https://sanity.nuxtjs.org/getting-started/configuration) for this module its says that you can also pass options through nuxt runtime configuration. This works as intended except when the proejctId is only specified in the runtime config. The config is [validated ](https://github.com/nuxt-community/sanity-module/blob/ee743c5687ace2bd5f8de40e0ad4049a9514aba0/src/module.ts#L88)bevor it is [merged ](https://github.com/nuxt-community/sanity-module/blob/ee743c5687ace2bd5f8de40e0ad4049a9514aba0/src/module.ts#L104)with option specified in the runtime config. Therefore, when the projectId is specified only in the runtime config the config is deemed invalid and the module won’t be initialized.

This problem could be solved if the options specified in runtime config are merged into the default options as shown in this pull request. I think this would also make this [part ](https://github.com/nuxt-community/sanity-module/blob/ee743c5687ace2bd5f8de40e0ad4049a9514aba0/src/module.ts#L104)redundant but I’m not sure.

Happy to hear your opinions on this topic!