### PR TITLE
docs: add missing `.url()` call

### DIFF
--- a/docs/pages/en/2.helpers/2.images.md
+++ b/docs/pages/en/2.helpers/2.images.md
@@ -79,7 +79,7 @@ Then you can use the global `$urlFor` helper:
 ```vue
 <template>
   <img
-    :src="$urlFor(movie.image).size(426)"
+    :src="$urlFor(movie.image).size(426).url()"
     :alt="movie.title"
     height="426"
     width="426"


### PR DESCRIPTION
according to https://github.com/sanity-io/image-url#usage, one needs to add `url()` to function.

in my limited testing, this appeared to be true