### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 1. Add `@nuxtjs/sanity` dependency to your project
 
 ```bash
-yarn add @nuxtjs/sanity # or npm install @nuxtjs/sanity
+npx nuxi@latest module add sanity
 ```
 
 2. Add `@nuxtjs/sanity` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -9,15 +9,9 @@ v1 of this module works with Nuxt 3 and Nuxt Bridge. If you are looking for the 
 ## Setup
 
 1. **Install Sanity integration**
-
-    ::code-group
-      ```bash [Yarn]
-      yarn add @nuxtjs/sanity
-      ```
-      ```bash [NPM]
-      npm install @nuxtjs/sanity --save
-      ```
-    ::
+    ```bash
+    npx nuxi@latest module add sanity
+    ```
 
 2. **Enable the module in your Nuxt configuration**
 

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/nuxt-modules/sanity
-snippet: yarn add @nuxtjs/sanity
+snippet: npx nuxi@latest module add sanity
 ---
 
 #title


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
