### PR TITLE
docs: specify usage with `live-visual-editing`

### DIFF
--- a/docs/content/1.getting-started/5.visual-editing.md
+++ b/docs/content/1.getting-started/5.visual-editing.md
@@ -42,7 +42,7 @@ A Sanity read token used for server side queries. This is required in order to f
 
 Accepts one of the following options:
 
-- **`'live-visual-editing'`** - Default behaviour. Lets the module handle setup to provide fully featured visual editing with live updates. Queries should be executed using `useSanityQuery`.
+- **`'live-visual-editing'`** - Default behaviour. Lets the module handle setup to provide fully featured visual editing with live updates. Queries should be executed using `useSanityQuery` and Live Content must be enabled as outlined [here](/getting-started/live-content#enable-live-content).
 - **`'visual-editing'`** - Used to enable visual editing without live updates, for example if fetching data using the Sanity client directly. Passing a custom `refresh` handler is recommended, as by default the entire app will refresh to display updates.
 - **`'custom'`** - The module will not handle any setup, instead the `useSanityVisualEditing` and/or `useSanityLiveMode` composables will need to be called manually.
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
The docs for [configuring the Visual Editing mode](https://sanity.nuxtjs.org/getting-started/visual-editing#mode) don't call out that you need to enable Live Content for it to work, so this PR adds a callout with a link to the live content configuration docs. 
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
