### PR TITLE
fix: handle undefined return values in useSanityQuery

### DIFF
--- a/src/runtime/composables/useSanityQuery.ts
+++ b/src/runtime/composables/useSanityQuery.ts
@@ -171,12 +171,14 @@ export function useSanityQuery<T = unknown, E = Error>(
     const { result, resultSourceMap } = await client.fetch<T>(query, params || {}, options)
 
     updateRefs(result, resultSourceMap)
-    return { data: result, sourceMap: resultSourceMap }
-  }, options) as AsyncData<SanityQueryResponse<T | null>, E>
+    return { data: result, sourceMap: resultSourceMap } satisfies SanityQueryResponse<T>
+  }, options) as AsyncData<SanityQueryResponse<T | null> | undefined, E>
 
   return Object.assign(new Promise((resolve) => {
     result.then((value) => {
-      updateRefs(value.data.value.data, value.data.value.sourceMap)
+      if (value.data.value) {
+        updateRefs(value.data.value.data, value.data.value.sourceMap)
+      }
       resolve({
         ...result,
         data,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1344

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the `useSanityQuery` composable, the return type asserted on `useAsyncData` (I'd prefer not to assert this type if possible!) didn't include `undefined`, so we incorrectly assumed we would always have a return value. If the internal fetch failed, for example as a result of a network error, accessing the nested `data` property that the type incorrectly assured us was defined, would throw an error.

**Changes:**
1. Added a runtime check to make sure the return value is actually defined.
2. Updated the type annotation to include `undefined`, matching the actual runtime behaviour.
