### PR TITLE
feat: re-export portable text types

### DIFF
--- a/docs/content/2.helpers/1.portable-text.md
+++ b/docs/content/2.helpers/1.portable-text.md
@@ -169,6 +169,36 @@ const handleMissingComponent = (message, options) => {
 </script>
 ```
 
+### TypeScript Support
+
+All types from `@portabletext/vue` and `@portabletext/types` are re-exported from `@nuxtjs/sanity`:
+
+```vue
+<script setup lang="ts">
+import type { PortableTextComponents } from '@nuxtjs/sanity/runtime/types'
+import { defineAsyncComponent, h } from 'vue'
+import CustomBlockComponent from '~/components/CustomBlockComponent.vue'
+
+const components: PortableTextComponents = {
+  types: {
+    customBlock: props => h(CustomBlockComponent, {
+      ...props.value,
+    }),
+  },
+  marks: {
+    link: props => h('a', {
+      href: props.value.href,
+      target: '_blank'
+    }, props.text)
+  }
+}
+</script>
+
+<template>
+  <SanityContent :value="content" :components="components" />
+</template>
+```
+
 ## Other resources
 
 - [@portabletext/vue](https://github.com/portabletext/vue-portabletext){ .text-primary-500 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -227,3 +227,18 @@ export type SanityResolvedConfig
     }
 
 export type SanityVisualEditingZIndex = VisualEditingOptions['zIndex']
+
+/**
+ * Re-export all types from @portabletext/vue
+ * Allows users to import portable text types directly from @nuxtjs/sanity
+ * without needing to install @portabletext/vue separately
+ * @public
+ */
+export type * from '@portabletext/vue'
+
+/**
+ * Re-export types from @portabletext/types
+ * These are the core Portable Text type definitions used by components
+ * @public
+ */
+export type * from '@portabletext/types'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1400

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds (re-)exports for all types from `@portabletext/vue` and `@portabletext/types`.

They can be imported from `@nuxtjs/sanity/runtime/types`.

**Changes:**
- Added type re-exports in `src/runtime/types.ts` for `@portabletext/vue` and `@portabletext/types`.
- Added TypeScript Support section to Portable Text documentation.