### PR TITLE
fix: correct perspective handling in useSanityQuery

### DIFF
--- a/src/runtime/composables/useSanityPerspective.ts
+++ b/src/runtime/composables/useSanityPerspective.ts
@@ -42,7 +42,7 @@ const sanitizePerspective = (
   }
 }
 
-export const useSanityPerspective = (perspective?: ClientPerspective) => {
+export const useSanityPerspective = (perspective?: ClientPerspective, fallback?: ClientPerspective) => {
   const visualEditingState = useSanityVisualEditingState()
 
   const devMode = import.meta.dev
@@ -66,7 +66,7 @@ export const useSanityPerspective = (perspective?: ClientPerspective) => {
       if (visualEditingState?.enabled) {
         return sanitizePerspective(cookie.value, 'drafts')
       }
-      return 'published'
+      return fallback || 'published'
     },
     set(perspective) {
       try {

--- a/src/runtime/composables/useSanityQuery.ts
+++ b/src/runtime/composables/useSanityQuery.ts
@@ -72,8 +72,7 @@ export function useSanityQuery<T = unknown, E = Error>(
   const params = _params ? reactive(_params) : undefined
   const queryKey = 'sanity-' + hash(query + (params ? JSON.stringify(params) : ''))
 
-  // Visual editing overrides
-  const perspective = useSanityPerspective(_perspective)
+  const perspective = useSanityPerspective(_perspective, clientConfig.perspective)
   const stega = _stega ?? (
     clientConfig.stega?.enabled
     && typeof clientConfig.stega.studioUrl !== 'undefined'
@@ -100,9 +99,9 @@ export function useSanityQuery<T = unknown, E = Error>(
     )
   }
 
-  const client = import.meta.server || perspective.value === 'published'
-    ? sanity.client // On the server or fetching published content
-    : createProxyClient() // Otherwise use proxy for authenticated requests
+  const client = import.meta.client && visualEditingState?.enabled && perspective.value !== 'published'
+    ? createProxyClient() // Use proxy for authenticated client-side requests when visual editing is enabled
+    : sanity.client // On the server, or fetching published content, or visual editing not enabled
 
   // Handle query updates, using either the query loader or tag based
   // revalidation (Live Content API). The query loader is preferred when in


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1387

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `sanity.perspective` option configured in `nuxt.config.ts` was being ignored by `useSanityQuery`. Requests would always use `perspective=published` regardless of the configured value.

`useSanityQuery` was calling `useSanityPerspective()` without passing the client's configured perspective. When no explicit perspective was provided and visual editing wasn't enabled, `useSanityPerspective` would default to `'published'` instead of using the module config.

- Added a `fallback` parameter to `useSanityPerspective()` 
- `useSanityQuery` now passes `clientConfig.perspective` as the fallback
- Fixed proxy client logic to only activate when visual editing is enabled