### PR TITLE
fix: resolve correct `useSanityQuery` fetch options

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="3.23.0"
+setups.@nuxt/test-utils="4.0.0"

--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -88,7 +88,7 @@ Include credentials in requests made to Sanity. Useful if you want to take advan
 ### `useCdn`
 
 - Type: **boolean**
-- Default: **`true`** in production or **`false`** if a token has been passed in
+- Default: **`true`**
 
 ### `minimal`
 

--- a/docs/content/1.getting-started/4.usage.md
+++ b/docs/content/1.getting-started/4.usage.md
@@ -26,6 +26,22 @@ const query = groq`*[_type == "post" && topic == $topic][0..10]`
 const { data, refresh } = useSanityQuery<Post>(query, { topic: 'News' })
 ```
 
+### Query Options
+
+You can pass a `queryOptions` object to customise the options sent to the underlying Sanity client fetch call. This allows you to override the automatically resolved options for specific queries.
+
+```ts
+const { data } = useSanityQuery(query, params, {
+  queryOptions: {
+    perspective: 'published',
+    tag: 'my-custom-tag',
+    useCdn: false,
+  },
+})
+```
+
+Any options passed via `queryOptions` will take priority over the module's automatically resolved values. See the [`@sanity/client` documentation](https://www.sanity.io/docs/js-client#fetch) for the full list of available options.
+
 ### Automatic Type Generation
 
 When [type generation](/getting-started/typegen) is enabled, you can use auto-generated types based on your query variable names:

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -2,4 +2,13 @@ import type { createClient } from '#sanity-client'
 
 export type SanityClient = ReturnType<typeof createClient>
 export { createClient } from '#sanity-client'
-export type { ClientConfig, ContentSourceMap, QueryParams, QueryOptions } from '#sanity-client'
+export type {
+  ClientPerspective,
+  ClientConfig,
+  ContentSourceMap,
+  InitializedClientConfig,
+  QueryParams,
+  QueryOptions,
+  StegaConfig,
+  UnfilteredResponseQueryOptions,
+} from '#sanity-client'

--- a/src/runtime/composables/useSanityQuery.ts
+++ b/src/runtime/composables/useSanityQuery.ts
@@ -5,8 +5,9 @@ import type { EncodeDataAttributeFunction } from '@sanity/core-loader/encode-dat
 import type { ClientReturn } from '@sanity/client'
 import { useAsyncData } from '#imports'
 import { reactive, ref, watch, type Ref } from 'vue'
-import type { ClientConfig, ContentSourceMap, QueryParams, QueryOptions, SanityClient } from '../client'
+import type { ContentSourceMap, QueryParams } from '../client'
 import type { AsyncSanityData, Noop, SanityQueryResponse, UseSanityQueryOptions } from '../types'
+import { resolveFetchOptions } from '../util/resolveFetchOptions'
 import { useSanity } from './useSanity'
 import { useSanityConfig } from './useSanityConfig'
 import { useIsSanityPresentationTool } from './useIsSanityPresentationTool'
@@ -15,28 +16,6 @@ import { useSanityVisualEditingState } from './useSanityVisualEditingState'
 import { createForwardingClient } from '../util/createForwardingClient'
 import { useSanityTagRevalidation } from './internal/useSanityTagRevalidation'
 import { useSanityQueryFetcher } from './internal/useSanityQueryFetcher'
-
-const getToken = (
-  {
-    config,
-    client,
-    perspective,
-  }: {
-    config: ReturnType<typeof useSanityConfig>
-    client: SanityClient
-    perspective: ClientConfig['perspective']
-  }) => {
-  if (perspective === 'published') {
-    return client.config().token || undefined
-  }
-  if (config.liveContent?.serverToken) {
-    return config.liveContent.serverToken
-  }
-  if (config.visualEditing) {
-    return config.visualEditing.token
-  }
-  return undefined
-}
 
 export function useSanityQuery<const Q extends string, E = Error>(
   query: Q,
@@ -58,10 +37,14 @@ export function useSanityQuery<T = unknown, E = Error>(
   const {
     client: _client,
     key: _key,
-    perspective: _perspective,
-    stega: _stega,
+    perspective: legacyPerspectiveParam,
+    stega: legacyStegaParam,
+    queryOptions,
     ...options
   } = _options
+
+  const perspectiveOption = queryOptions?.perspective ?? legacyPerspectiveParam
+  const stegaOption = queryOptions?.stega ?? legacyStegaParam
 
   // Get configuration
   const sanity = useSanity(_client)
@@ -73,12 +56,7 @@ export function useSanityQuery<T = unknown, E = Error>(
   const params = _params ? reactive(_params) : undefined
   const queryKey = _key || 'sanity-' + hash(query + (params ? JSON.stringify(params) : ''))
 
-  const perspective = useSanityPerspective(_perspective, clientConfig.perspective)
-  const stega = _stega ?? (
-    clientConfig.stega?.enabled
-    && typeof clientConfig.stega.studioUrl !== 'undefined'
-    && visualEditingState?.enabled
-  )
+  const perspective = useSanityPerspective(perspectiveOption, clientConfig.perspective)
 
   options.watch = options.watch || []
   options.watch.push(perspective)
@@ -150,28 +128,25 @@ export function useSanityQuery<T = unknown, E = Error>(
   }, { immediate: true })
 
   const result = useAsyncData(queryKey, async () => {
-    const useCdn = perspective.value === 'published'
-    const token = getToken({
-      config,
-      client: sanity.client,
+    const options = resolveFetchOptions({
+      clientConfig,
+      lastLiveEventId: tagRevalidation?.getLastLiveEventId(),
+      liveContentEnabled: !!config.liveContent,
       perspective: perspective.value,
+      queryOptions,
+      runtimeConfig: config,
+      stega: stegaOption,
+      visualEditingEnabled: !!visualEditingState?.enabled,
     })
 
-    const options = {
-      cacheMode: useCdn ? 'noStale' : undefined,
+    await tagRevalidation?.fetchTags(query, params, {
+      cacheMode: perspective.value === 'published' ? 'noStale' : undefined,
       filterResponse: false,
-      lastLiveEventId: tagRevalidation?.getLastLiveEventId(),
       perspective: perspective.value,
-      resultSourceMap: 'withKeyArraySelector',
-      stega,
-      token,
-      useCdn,
-    } satisfies QueryOptions
-
-    await tagRevalidation?.fetchTags(query, params, options)
+      useCdn: perspective.value === 'published',
+    })
 
     const { result, resultSourceMap } = await client.fetch<T>(query, params || {}, options)
-
     updateRefs(result, resultSourceMap)
     return { data: result, sourceMap: resultSourceMap } satisfies SanityQueryResponse<T>
   }, options) as AsyncData<SanityQueryResponse<T | null> | undefined, E>

--- a/src/runtime/minimal-client.ts
+++ b/src/runtime/minimal-client.ts
@@ -7,14 +7,26 @@ import { $fetch } from 'ofetch'
 const apiHost = 'api.sanity.io'
 const cdnHost = 'apicdn.sanity.io'
 
+export type ClientPerspective = 'raw' | 'published' | 'drafts' | 'previewDrafts'
+
 export type QueryParams = Record<string, unknown>
 
 export interface QueryOptions {
-  perspective?: ClientConfig['perspective']
+  perspective?: ClientPerspective
   filterResponse?: boolean
+  [key: string]: unknown
+}
+
+export type UnfilteredResponseQueryOptions = QueryOptions & {
+  filterResponse: false
 }
 
 export type ContentSourceMap = unknown
+
+export interface StegaConfig {
+  enabled?: boolean
+  studioUrl?: string
+}
 
 export interface ClientConfig {
   useCdn?: boolean
@@ -23,7 +35,11 @@ export interface ClientConfig {
   apiVersion: string
   withCredentials?: boolean
   token?: string
-  perspective?: 'raw' | 'published' | 'drafts' | 'previewDrafts'
+  perspective?: ClientPerspective
+}
+
+export interface InitializedClientConfig extends ClientConfig {
+  stega?: StegaConfig
 }
 
 /** @deprecated Prefer `ClientConfig` instead - this will be removed in a future version. */

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -4,7 +4,7 @@ import type { QueryStore } from '@sanity/core-loader'
 import type { AsyncDataOptions } from 'nuxt/app'
 import type { ClientPerspective, ContentSourceMap, StegaConfig } from '@sanity/client'
 import type { EncodeDataAttributeFunction } from '@sanity/core-loader/encode-data-attribute'
-import type { ClientConfig, SanityClient } from './client'
+import type { ClientConfig, QueryOptions, SanityClient } from './client'
 
 /**
  * Augmented version of Nuxt's _AsyncData, with additional properties like
@@ -119,7 +119,10 @@ export interface SanityLiveStore {
 export interface UseSanityQueryOptions<T> extends AsyncDataOptions<T> {
   client?: string
   key?: string
+  queryOptions?: QueryOptions
+  /** @deprecated Use `queryOptions.perspective` instead. */
   perspective?: ClientPerspective
+  /** @deprecated Use `queryOptions.stega` instead. */
   stega?: boolean
 }
 

--- a/src/runtime/util/resolveFetchOptions.ts
+++ b/src/runtime/util/resolveFetchOptions.ts
@@ -1,0 +1,82 @@
+import type { ClientPerspective, InitializedClientConfig, QueryOptions, StegaConfig, UnfilteredResponseQueryOptions } from '../client'
+import type { SanityResolvedConfig } from '../types'
+
+function stripUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as T
+}
+
+export function resolveFetchOptions({
+  clientConfig,
+  lastLiveEventId,
+  liveContentEnabled,
+  perspective,
+  queryOptions,
+  runtimeConfig,
+  stega,
+  visualEditingEnabled,
+}: {
+  clientConfig?: InitializedClientConfig
+  lastLiveEventId?: string
+  liveContentEnabled?: boolean
+  perspective?: ClientPerspective
+  queryOptions?: QueryOptions
+  runtimeConfig?: SanityResolvedConfig
+  stega?: StegaConfig | boolean
+  visualEditingEnabled?: boolean
+}): UnfilteredResponseQueryOptions {
+  // Stega encoding is only enabled when configured on the client and visual
+  // editing is enabled, unless explicitly set in the query options.
+  const stegaFromClientConfig = (
+    clientConfig?.stega?.enabled
+    && typeof clientConfig?.stega.studioUrl !== 'undefined'
+    && visualEditingEnabled
+  ) || undefined
+  const resolvedStega = stega ?? stegaFromClientConfig
+
+  // These tokens grant access to draft content, so they are only included
+  // when fetching content for an explicit draft perspective. For 'published'
+  // and 'raw' (the default), the client's own token (if any) is sufficient.
+  // The visual editing token additionally requires visual editing to be
+  // enabled, since it is specifically intended for that context.
+  const needsDraftToken = perspective !== 'published' && perspective !== 'raw'
+  const tokenFromRuntimeConfig = needsDraftToken
+    ? (runtimeConfig?.liveContent?.serverToken
+      ?? (visualEditingEnabled ? runtimeConfig?.visualEditing?.token : undefined))
+    : undefined
+  const resolvedToken = queryOptions?.token ?? tokenFromRuntimeConfig
+
+  // When using the Live Content API, we use the CDN for published content and
+  // bypass it for drafts. Without LCAPI, we leave useCdn unset so the client's
+  // own configuration applies.
+  const resolvedUseCdn = queryOptions?.useCdn
+    ?? (liveContentEnabled ? perspective === 'published' : undefined)
+
+  // Use 'noStale' when Live Content API is enabled and fetching published
+  // content using the CDN.
+  const resolvedCacheMode = queryOptions?.cacheMode
+    ?? (liveContentEnabled && resolvedUseCdn ? 'noStale' as const : undefined)
+
+  // Only enable source maps when visual editing is enabled, unless explicitly
+  // set in the query options.
+  const resolvedResultSourceMap = queryOptions?.resultSourceMap
+    ?? (visualEditingEnabled ? 'withKeyArraySelector' : undefined)
+
+  return {
+    // Pass through user-provided query options unmodified.
+    ...queryOptions,
+    // Our resolved values override queryOptions only when defined. Undefined
+    // values are stripped so they don't shadow queryOptions or override
+    // client-level defaults.
+    ...stripUndefined({
+      filterResponse: false as const,
+      returnQuery: true as const,
+      resultSourceMap: resolvedResultSourceMap,
+      cacheMode: resolvedCacheMode,
+      lastLiveEventId,
+      perspective,
+      stega: resolvedStega,
+      token: resolvedToken,
+      useCdn: resolvedUseCdn,
+    }),
+  }
+}

--- a/test/unit/resolveFetchOptions.test.ts
+++ b/test/unit/resolveFetchOptions.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest'
+import { resolveFetchOptions } from '../../src/runtime/util/resolveFetchOptions'
+
+describe('resolveFetchOptions', () => {
+  it('returns expected defaults with no arguments', () => {
+    expect(resolveFetchOptions({})).toEqual({
+      filterResponse: false,
+      returnQuery: true,
+    })
+  })
+
+  describe('queryOptions', () => {
+    it('spreads properties into the result', () => {
+      const opts = resolveFetchOptions({ queryOptions: { tag: 'my-tag' } })
+      expect(opts.tag).toBe('my-tag')
+    })
+
+    it('filterResponse is always false', () => {
+      const opts = resolveFetchOptions({ queryOptions: { filterResponse: true } })
+      expect(opts.filterResponse).toBe(false)
+    })
+
+    it('returnQuery is always true', () => {
+      const opts = resolveFetchOptions({ queryOptions: { returnQuery: false } })
+      expect(opts.returnQuery).toBe(true)
+    })
+
+    it('perspective takes priority over queryOptions.perspective', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'drafts',
+        queryOptions: { perspective: 'published' },
+      })
+      expect(opts.perspective).toBe('drafts')
+    })
+
+    it('queryOptions.resultSourceMap takes priority over visualEditingEnabled', () => {
+      const opts = resolveFetchOptions({
+        visualEditingEnabled: true,
+        queryOptions: { resultSourceMap: false },
+      })
+      expect(opts.resultSourceMap).toBe(false)
+    })
+
+    it('lastLiveEventId takes priority over queryOptions.lastLiveEventId', () => {
+      const opts = resolveFetchOptions({
+        lastLiveEventId: 'event-123',
+        queryOptions: { lastLiveEventId: 'event-456' },
+      })
+      expect(opts.lastLiveEventId).toBe('event-123')
+    })
+
+    it('useCdn takes priority over queryOptions.useCdn', () => {
+      const opts = resolveFetchOptions({
+        liveContentEnabled: true,
+        perspective: 'published',
+        queryOptions: { useCdn: false },
+      })
+      expect(opts.useCdn).toBe(false)
+    })
+
+    it('queryOptions.cacheMode is used even when it would otherwise be omitted', () => {
+      const opts = resolveFetchOptions({
+        liveContentEnabled: true,
+        perspective: 'drafts',
+        queryOptions: { cacheMode: 'noStale' },
+      })
+      expect(opts.cacheMode).toBe('noStale')
+    })
+  })
+
+  describe('token resolution', () => {
+    it('uses queryOptions.token when no config tokens are set', () => {
+      const opts = resolveFetchOptions({ queryOptions: { token: 'user-token' } })
+      expect(opts.token).toBe('user-token')
+    })
+
+    it('queryOptions.token takes priority over liveContent.serverToken', () => {
+      const opts = resolveFetchOptions({
+        queryOptions: { token: 'user-token' },
+        runtimeConfig: { liveContent: { serverToken: 'live-token' } } as any,
+      })
+      expect(opts.token).toBe('user-token')
+    })
+
+    it('queryOptions.token takes priority over visualEditing.token', () => {
+      const opts = resolveFetchOptions({
+        queryOptions: { token: 'user-token' },
+        runtimeConfig: { visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBe('user-token')
+    })
+
+    it('liveContent.serverToken takes priority over visualEditing.token', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'drafts',
+        visualEditingEnabled: true,
+        runtimeConfig: { liveContent: { serverToken: 'live-token' }, visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBe('live-token')
+    })
+
+    it('uses liveContent.serverToken for non-published perspective without visual editing', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'drafts',
+        runtimeConfig: { liveContent: { serverToken: 'live-token' } } as any,
+      })
+      expect(opts.token).toBe('live-token')
+    })
+
+    it('uses visualEditing.token when visual editing is enabled and perspective is not published', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'drafts',
+        visualEditingEnabled: true,
+        runtimeConfig: { visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBe('ve-token')
+    })
+
+    it('omits visualEditing.token when visual editing is not enabled', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'drafts',
+        runtimeConfig: { visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBeUndefined()
+    })
+
+    it('is omitted for published perspective even if runtimeConfig tokens exist', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'published',
+        visualEditingEnabled: true,
+        runtimeConfig: { liveContent: { serverToken: 'live-token' }, visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBeUndefined()
+    })
+
+    it('is omitted for raw perspective even if runtimeConfig tokens exist', () => {
+      const opts = resolveFetchOptions({
+        perspective: 'raw',
+        visualEditingEnabled: true,
+        runtimeConfig: { liveContent: { serverToken: 'live-token' }, visualEditing: { token: 've-token' } } as any,
+      })
+      expect(opts.token).toBeUndefined()
+    })
+
+    it('is omitted when nothing is configured', () => {
+      const opts = resolveFetchOptions({})
+      expect(opts.token).toBeUndefined()
+    })
+  })
+
+  describe('stega resolution', () => {
+    it('uses explicit stega option', () => {
+      const opts = resolveFetchOptions({ stega: true })
+      expect(opts.stega).toBe(true)
+    })
+
+    it('explicit stega takes priority over client config', () => {
+      const opts = resolveFetchOptions({
+        stega: false,
+        visualEditingEnabled: true,
+        clientConfig: { stega: { enabled: true, studioUrl: 'https://studio.test' } } as any,
+      })
+      expect(opts.stega).toBe(false)
+    })
+
+    it('falls back to client config when stega is not set', () => {
+      const opts = resolveFetchOptions({
+        visualEditingEnabled: true,
+        clientConfig: { stega: { enabled: true, studioUrl: 'https://studio.test' } } as any,
+      })
+      expect(opts.stega).toBe(true)
+    })
+
+    it('is omitted when nothing is configured', () => {
+      const opts = resolveFetchOptions({})
+      expect(opts.stega).toBeUndefined()
+    })
+
+    it('is omitted when client config stega has no studioUrl', () => {
+      const opts = resolveFetchOptions({
+        visualEditingEnabled: true,
+        clientConfig: { stega: { enabled: true, studioUrl: undefined } } as any,
+      })
+      expect(opts.stega).toBeUndefined()
+    })
+
+    it('is omitted when visual editing is not enabled', () => {
+      const opts = resolveFetchOptions({
+        clientConfig: { stega: { enabled: true, studioUrl: 'https://studio.test' } } as any,
+      })
+      expect(opts.stega).toBeUndefined()
+    })
+
+    it('is omitted when client config stega is not enabled', () => {
+      const opts = resolveFetchOptions({
+        visualEditingEnabled: true,
+        clientConfig: { stega: { enabled: false, studioUrl: 'https://studio.test' } } as any,
+      })
+      expect(opts.stega).toBeUndefined()
+    })
+  })
+
+  describe('resultSourceMap', () => {
+    it('is withKeyArraySelector when visual editing is enabled', () => {
+      const opts = resolveFetchOptions({ visualEditingEnabled: true })
+      expect(opts.resultSourceMap).toBe('withKeyArraySelector')
+    })
+
+    it('is omitted when visual editing is not enabled', () => {
+      const opts = resolveFetchOptions({})
+      expect(opts.resultSourceMap).toBeUndefined()
+    })
+  })
+
+  describe('useCdn and cacheMode', () => {
+    it('are omitted when liveContentEnabled is false', () => {
+      const opts = resolveFetchOptions({ perspective: 'published' })
+      expect(opts.useCdn).toBeUndefined()
+      expect(opts.cacheMode).toBeUndefined()
+    })
+
+    it('useCdn is true and cacheMode is noStale for published perspective with LCAPI', () => {
+      const opts = resolveFetchOptions({ liveContentEnabled: true, perspective: 'published' })
+      expect(opts.useCdn).toBe(true)
+      expect(opts.cacheMode).toBe('noStale')
+    })
+
+    it('useCdn is false and cacheMode is omitted for non-published perspective with LCAPI', () => {
+      const opts = resolveFetchOptions({ liveContentEnabled: true, perspective: 'drafts' })
+      expect(opts.useCdn).toBe(false)
+      expect(opts.cacheMode).toBeUndefined()
+    })
+  })
+
+  describe('integration', () => {
+    it('resolves all options for a published LCAPI request with visual editing', () => {
+      expect(resolveFetchOptions({
+        clientConfig: { stega: { enabled: true, studioUrl: 'https://studio.test' } } as any,
+        lastLiveEventId: 'event-1',
+        liveContentEnabled: true,
+        perspective: 'published',
+        runtimeConfig: { liveContent: { serverToken: 'server-token' } } as any,
+        visualEditingEnabled: true,
+      })).toEqual({
+        cacheMode: 'noStale',
+        filterResponse: false,
+        lastLiveEventId: 'event-1',
+        perspective: 'published',
+        resultSourceMap: 'withKeyArraySelector',
+        returnQuery: true,
+        stega: true,
+        useCdn: true,
+      })
+    })
+
+    it('resolves all options for a drafts LCAPI request with visual editing', () => {
+      expect(resolveFetchOptions({
+        lastLiveEventId: 'event-2',
+        liveContentEnabled: true,
+        perspective: 'drafts',
+        runtimeConfig: { liveContent: { serverToken: 'server-token' } } as any,
+        visualEditingEnabled: true,
+      })).toEqual({
+        filterResponse: false,
+        lastLiveEventId: 'event-2',
+        perspective: 'drafts',
+        resultSourceMap: 'withKeyArraySelector',
+        returnQuery: true,
+        token: 'server-token',
+        useCdn: false,
+      })
+    })
+
+    it('resolves all options for a simple request without LCAPI or visual editing', () => {
+      expect(resolveFetchOptions({
+        perspective: 'published',
+      })).toEqual({
+        filterResponse: false,
+        perspective: 'published',
+        returnQuery: true,
+      })
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1410

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

Previously, `useSanityQuery` constructed the fetch options inline with several quite significant issues:

- **Draft content could be inadvertently fetched**: The `liveContent.serverToken` and `visualEditing.token` were always included in fetch requests if present on the server, regardless of whether visual editing was active. This means that when combined with the default `'raw'` perspective, users could receive content across all perspectives (e.g. published + draft) in SSR responses.
- **Options were always set regardless of context**: `resultSourceMap`, `stega`, `useCdn`, and `cacheMode` were set on every request even when unnecessary. Source maps were fetched even without visual editing, and CDN options were set even without the Live Content API.
- **No way for users to customise fetch options**: There was no mechanism for users to pass through their own query options (e.g. `tag`, `cache`) except for `perspective` and `stega` to the internal client fetch call.

This PR extracts fetch option resolution into a dedicated `resolveFetchOptions` utility:

- **Supports user defined fetch options**: a new `options.queryOptions` property on `useSanityQuery` allows users to pass arbitrary options to the internal Sanity client fetch call. The resolved values only override them when explicitly defined. The current top level `perspective` and `stega` properties are soft deprecated in favour of using `queryOptions`. We _could_ flatten the options, but it felt like the potential for property name clashes was significant enough that having a nested object made more sense.
- **Tokens are gated on perspective**: `liveContent.serverToken` is only included when the perspective is not `'published'` or `'raw'`. `visualEditing.token` additionally requires visual editing to be enabled, since it is specifically intended for that context. Users can still pass their own token via `queryOptions.token` to override this behaviour.
- **CDN options are gated on LCAPI**: `useCdn` and `cacheMode` are only set when the Live Content API is active and the relevant perspective is being used. Without LCAPI, the client's own `useCdn` configuration applies.
- **Source maps and stega are gated on visual editing**: these are only necessary for visual editing, this is quite a significant one for reducing unnecessary payload sizes.