### PR TITLE
feat: support custom key option for queries

### DIFF
--- a/src/runtime/composables/useLazySanityQuery.ts
+++ b/src/runtime/composables/useLazySanityQuery.ts
@@ -24,7 +24,7 @@ export function useLazySanityQuery<T = unknown, E = Error>(
   _params?: QueryParams,
   _options: UseSanityQueryOptions<T | null> = {},
 ): AsyncData<T | null, E> {
-  const { client, ...options } = _options
+  const { client, key, ...options } = _options
   const sanity = useSanity(client)
   const params = _params ? reactive(_params) : undefined
 
@@ -34,7 +34,7 @@ export function useLazySanityQuery<T = unknown, E = Error>(
   }
 
   return useLazyAsyncData(
-    'sanity-' + hash(query + (params ? JSON.stringify(params) : '')),
+    key || 'sanity-' + hash(query + (params ? JSON.stringify(params) : '')),
     () => sanity.fetch<T>(query, params || {}),
     options,
   ) as AsyncData<T | null, E>

--- a/src/runtime/composables/useSanityQuery.ts
+++ b/src/runtime/composables/useSanityQuery.ts
@@ -57,6 +57,7 @@ export function useSanityQuery<T = unknown, E = Error>(
 ): AsyncSanityData<T | null, E> {
   const {
     client: _client,
+    key: _key,
     perspective: _perspective,
     stega: _stega,
     ...options
@@ -70,7 +71,7 @@ export function useSanityQuery<T = unknown, E = Error>(
   const clientConfig = sanity.client.config()
 
   const params = _params ? reactive(_params) : undefined
-  const queryKey = 'sanity-' + hash(query + (params ? JSON.stringify(params) : ''))
+  const queryKey = _key || 'sanity-' + hash(query + (params ? JSON.stringify(params) : ''))
 
   const perspective = useSanityPerspective(_perspective, clientConfig.perspective)
   const stega = _stega ?? (

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -118,6 +118,7 @@ export interface SanityLiveStore {
  */
 export interface UseSanityQueryOptions<T> extends AsyncDataOptions<T> {
   client?: string
+  key?: string
   perspective?: ClientPerspective
   stega?: boolean
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1208

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Adds an optional `key` property to the options object for `useSanityQuery` and `useLazySanityQuery` which is passed directly to the underlying `useAsyncData`/`useLazyAsyncData` call, allowing users to define a predictable cache key for their queries. Useful when you need to access cached query data elsewhere in your app using `useNuxtData`.

When `key` is not provided, the behaviour is unchanged, a deterministic key is auto-generated from a hash of the query and params.