### PR TITLE
docs: remove references to nuxt 2 and bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 - Ultra-lightweight Sanity client
 - Zero-config image/file components + portable text renderer
 - Supports GROQ syntax highlighting
-- Nuxt 3 and Nuxt Bridge support
 
 [📖 &nbsp;Read more](https://sanity.nuxtjs.org)
 

--- a/docs/content/1.getting-started/4.usage.md
+++ b/docs/content/1.getting-started/4.usage.md
@@ -5,15 +5,11 @@
 
 ## useSanityQuery
 
-This is a data fetching composable that wraps `useAsyncData` from Nuxt 3 (see [docs](https://nuxt.com/docs/getting-started/data-fetching#useasyncdata)).
+This is a data fetching composable that wraps `useAsyncData` from Nuxt (see [docs](https://nuxt.com/docs/getting-started/data-fetching#useasyncdata)).
 
 The only mandatory argument is the query for it to fetch. You can also pass params, and an options object. In addition to the options you can pass to `useAsyncData`, there is also a `client` option for specifying which configured Sanity client you would like to use.
 
 If you pass any ref/computed parameters in `params`, `useSanityQuery` will automatically refetch the query when these parameters change.
-
-::tip
-This composable is only available in Nuxt 3. For Bridge, you will need to use `useLazySanityQuery` instead.
-::
 
 ### Example
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -84,15 +84,4 @@ Everything you need for your Nuxt project
   #description
   Write your GROQ queries with syntax highlighting and get full type-safety for your data.
   :::
-
-  :::u-page-feature
-  ---
-  icon: i-simple-icons-nuxt
-  ---
-  #title
-  Nuxt 3 & Bridge
-  
-  #description
-  Works perfectly with Nuxt 3 and Nuxt Bridge for any of your projects.
-  :::
 ::


### PR DESCRIPTION
…be Nuxt where relevant

### 🔗 Linked issue
resolves #1427

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Removes references to nuxt 2. I simply removed one of the feature cards on the homepage so a new one might be appriciated
