### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [20]
+        node: [22]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@10.32.0",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=23.0.0"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,17 +5,18 @@ packages:
 
 ignoreWorkspaceRootCheck: true
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - vue-demi
-
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
-  - better-sqlite3
-  - sharp
-
 overrides:
   "@nuxt/schema": "4.4.5"
   "@nuxtjs/sanity": "link:."
   nuxt-component-meta: "0.17.2"
+
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  '@tailwindcss/oxide': true
+  better-sqlite3: true
+  esbuild: false
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`