### PR TITLE
fix: disable stega outside visual editing

### DIFF
--- a/src/runtime/util/resolveFetchOptions.ts
+++ b/src/runtime/util/resolveFetchOptions.ts
@@ -25,12 +25,13 @@ export function resolveFetchOptions({
   visualEditingEnabled?: boolean
 }): UnfilteredResponseQueryOptions {
   // Stega encoding is only enabled when configured on the client and visual
-  // editing is enabled, unless explicitly set in the query options.
-  const stegaFromClientConfig = (
-    clientConfig?.stega?.enabled
+  // editing is enabled, unless explicitly set in the query options. It must be
+  // explicitly disabled otherwise so the client does not fall back to its
+  // enabled default.
+  const stegaFromClientConfig = clientConfig?.stega?.enabled
     && typeof clientConfig?.stega.studioUrl !== 'undefined'
-    && visualEditingEnabled
-  ) || undefined
+    ? !!visualEditingEnabled
+    : undefined
   const resolvedStega = stega ?? stegaFromClientConfig
 
   // These tokens grant access to draft content, so they are only included

--- a/test/unit/resolveFetchOptions.test.ts
+++ b/test/unit/resolveFetchOptions.test.ts
@@ -184,11 +184,11 @@ describe('resolveFetchOptions', () => {
       expect(opts.stega).toBeUndefined()
     })
 
-    it('is omitted when visual editing is not enabled', () => {
+    it('is disabled when configured on the client but visual editing is not enabled', () => {
       const opts = resolveFetchOptions({
         clientConfig: { stega: { enabled: true, studioUrl: 'https://studio.test' } } as any,
       })
-      expect(opts.stega).toBeUndefined()
+      expect(opts.stega).toBe(false)
     })
 
     it('is omitted when client config stega is not enabled', () => {


### PR DESCRIPTION
## Summary

- explicitly disable client-configured stega when visual editing is inactive
- preserve explicit per-query `stega` overrides
- update the resolver regression test to require `stega: false` rather than an omitted option

## Problem

When visual editing is configured, the module creates the Sanity client with `stega.enabled: true`. `resolveFetchOptions()` intends to gate that client setting on `visualEditingEnabled`, but currently resolves the inactive state to `undefined`. `stripUndefined()` then removes the `stega` property from the fetch options.

For `@sanity/client`, an omitted per-fetch `stega` option does not disable stega: it falls back to the client-level configuration. As a result, regular published/anonymous fetches can still return stega-encoded strings while visual editing is inactive.

This regresses the preview-only behavior discussed in #1007 and fixed in #1023. The gap was reintroduced when #1421 moved option resolution into `resolveFetchOptions()` and gated stega by omission.

## Fix

When the client is configured with stega and a Studio URL, resolve the inherited fetch option to the boolean state of visual editing:

- `true` while visual editing is active
- `false` while visual editing is inactive

If stega is not configured on the client, the option remains omitted so existing client defaults are preserved. Explicit query-level values continue to take precedence.

## Impact

Published pages no longer receive invisible stega characters merely because visual editing is configured. Preview and Presentation mode continue to receive stega-encoded content when enabled.

## Validation

- `pnpm test:unit` — 60 tests passed
- `pnpm lint`
- `pnpm test:types`
