### PR TITLE
feat: expose `keepStegaOnCopy` and `onSuspiciousStega` visual editing options

### DIFF
--- a/docs/content/1.getting-started/5.visual-editing.md
+++ b/docs/content/1.getting-started/5.visual-editing.md
@@ -63,6 +63,35 @@ To enable preview mode with defaults, or optionally configure the endpoints used
 
 Used to enable or disable [stega](https://www.sanity.io/docs/loaders-and-overlays#1dbcc04a7093).
 
+#### `keepStegaOnCopy`
+
+- Type: **boolean**
+- Default: **false**
+
+While visual editing is enabled, stega-encoded metadata (invisible characters) is automatically stripped from clipboard data when content is copied from the page, so copied text can be pasted into other tools without the hidden characters tagging along. Set this option to `true` to opt out and keep stega in copied content.
+
+#### `onSuspiciousStega`
+
+- Type: **function**
+
+An optional callback that reports stega payloads found in places where they always cause bugs or bloat, such as `class`, `href`, `src`, `id` and other attributes, inside `<head>`, `<script>` or `<style>` contents, form values, or the page URL. Providing the callback opts in to the detection logic — when it isn't provided, no scanning runs.
+
+```ts{}[nuxt.config.ts]
+export default defineNuxtConfig({
+  sanity: {
+    visualEditing: {
+      // ... Visual editing config
+      onSuspiciousStega: (reports) => {
+        for (const report of reports) {
+          console.warn(`Stega found in ${report.kind}`, report)
+        }
+      },
+    }
+  },
+})
+```
+
+Each report includes the offending `element`, the `attribute` name (when applicable), the raw `value`, the `cleaned` value it should have been, and the decoded `sanity` edit info when available — pointing at the exact document and field that produced the value.
 
 #### `refresh`
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@sanity/presentation-comlink": "^2.0.0",
     "@sanity/preview-url-secret": "^4.0.0",
     "@sanity/schema": "^5.3.1",
-    "@sanity/visual-editing": "^5.0.0",
+    "@sanity/visual-editing": "^5.6.0",
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "groq": "^5.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,10 +33,10 @@ importers:
         version: 4.0.1
       '@sanity/core-loader':
         specifier: ^2.0.0
-        version: 2.0.6(@sanity/types@5.13.0(@types/react@19.2.14))(typescript@6.0.2)
+        version: 2.0.6(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)
       '@sanity/presentation-comlink':
         specifier: ^2.0.0
-        version: 2.0.1(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))
+        version: 2.0.1(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
       '@sanity/preview-url-secret':
         specifier: ^4.0.0
         version: 4.0.3(@sanity/client@7.22.1)
@@ -44,8 +44,8 @@ importers:
         specifier: ^5.3.1
         version: 5.13.0(@types/react@19.2.14)
       '@sanity/visual-editing':
-        specifier: ^5.0.0
-        version: 5.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+        specifier: ^5.6.0
+        version: 5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.22.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
       consola:
         specifier: ^3.2.3
         version: 3.4.2
@@ -202,10 +202,10 @@ importers:
     dependencies:
       '@sanity/debug-preview-url-secret-plugin':
         specifier: ^2.0.0
-        version: 2.0.7(@sanity/client@7.22.1)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+        version: 2.0.7(@sanity/client@7.24.0)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
       '@sanity/preview-url-secret':
         specifier: ^4.0.0
-        version: 4.0.3(@sanity/client@7.22.1)
+        version: 4.0.3(@sanity/client@7.24.0)
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
@@ -227,7 +227,7 @@ importers:
     devDependencies:
       '@sanity/vision':
         specifier: 5.13.0
-        version: 5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -2307,6 +2307,10 @@ packages:
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
 
+  '@isaacs/ttlcache@2.1.5':
+    resolution: {integrity: sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -4240,6 +4244,18 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
 
+  '@sanity/icons@3.8.0':
+    resolution: {integrity: sha512-LXa8eoE6U2e46L/9Pk6VU1aOWNxEqEG1osTb2YWItPIAa8MyXkICRwdNRWwW3kr5gmf+Sh2ZmfKol/Q+oGKSqw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^18.3 || ^19.0.0-0
+
+  '@sanity/icons@5.1.0':
+    resolution: {integrity: sha512-BPvLFBWnxpXCn9XKb5OgBzNNRZJI29TXRpuSXx1/nKJ8FaYuitFmKSAD0L8jC0kF/BKKUMThaY3TYJ0UuubbTQ==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      react: ^19
+
   '@sanity/id-utils@1.0.0':
     resolution: {integrity: sha512-2sb7tbdMDuUuVyocJPKG0gZBiOML/ovCe+mJiLrv1j69ODOfa2LfUjDVR+dRw/A/+XuxoJSSP8ebG7NiwTOgIA==}
     engines: {node: '>=18'}
@@ -4273,6 +4289,9 @@ packages:
   '@sanity/media-library-types@1.2.0':
     resolution: {integrity: sha512-p+Bw96I63SwBcMNA/L5dnMdEcS88EEDUDZ65LGuwOCMXrESRGMFCSxgc+0HnL0JXDIzgYgfrPuf1I3bO9QneAw==}
 
+  '@sanity/media-library-types@1.6.0':
+    resolution: {integrity: sha512-1Nqw8GSUr7E8AFue9luyTOM4Ev0ZlJ35SHcQrHZ6T68G5llfXw99e3GkLXzk6qYFk9r9fJaBTSpW5IyO2mObZQ==}
+
   '@sanity/message-protocol@0.12.0':
     resolution: {integrity: sha512-RMRWQG5yVkCZnnBHW3qxVbZGUOeXPBzFPdD9+pynQCTVZI7zYBEzjnY8lcSYjty+0unDHqeoqMPfBXhqs0rg2g==}
     engines: {node: '>=20.0.0'}
@@ -4299,6 +4318,14 @@ packages:
       xstate:
         optional: true
 
+  '@sanity/mutate@0.18.1':
+    resolution: {integrity: sha512-28iICKl33s9yr8XtgpoCHOb+l5kKVbd6CpFYi4Vx0fHNZcFiKDGdY+RzZrC34GWqb6M16wkxwtHSVbEmXbfTpw==}
+    peerDependencies:
+      xstate: ^5.19.0
+    peerDependenciesMeta:
+      xstate:
+        optional: true
+
   '@sanity/mutator@5.13.0':
     resolution: {integrity: sha512-BbkqQULNS+2sHngG+h1DpSjkRnHM/j+3qI03c0GYLbGOLfH8KNatdfpZFGMYm2SCQfSrxQgb0bJILcHYgK9prA==}
 
@@ -4306,11 +4333,21 @@ packages:
     resolution: {integrity: sha512-D0S2CfVyda99cd/8SnXxQ2tsVlVuRq4CAOjxRuF53evYmBhpWezSEpWKqAa0e1lunGBKK1EroxmOzb5ofNRwMg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@sanity/presentation-comlink@2.2.0':
+    resolution: {integrity: sha512-uHiiJNWER36S/M2R9B7iwf+R2GMV267kQCfIpQiGX+2C3aHwjFHjaEiPBF0aPOyBkHV2OfB3l7XSzyLIXYuQHQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
   '@sanity/preview-url-secret@4.0.3':
     resolution: {integrity: sha512-aVkOiVvQDDC08fp3hkhrcz32QmjX8tVlLz843NE5y2TPTV6sc/+yg+uG/vwzeGtuDn0mjsjFm4EPUw54MMyr+w==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@sanity/client': ^7.14.1
+
+  '@sanity/preview-url-secret@4.1.0':
+    resolution: {integrity: sha512-Zha42V94Q7vnSHOyCHtSihChX7asoVrDq7BCQ6xyAzoGZKdbP7FIOiSahfIN9Z1ZUEe5PJh6/HGx9+6e/y50NA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.23.2
 
   '@sanity/runtime-cli@14.4.0':
     resolution: {integrity: sha512-co+8XL/Rrrh92J3E7JSesWumIALe78dubpjbNNRE00JjMhGBGQZ91NKctnIMxA+ZelzxDcKcdE6bdU5A2m5LGQ==}
@@ -4357,8 +4394,22 @@ packages:
     peerDependencies:
       '@types/react': ^19.2
 
+  '@sanity/types@6.5.0':
+    resolution: {integrity: sha512-H3Qs1yeizArl69i3VSDHC20RxLUNo/yWWmzUl2dMOtyooHPLOaKOUv8WrsH1gLg+w++LvuELfwEcxN431DRcnw==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@sanity/ui@3.1.13':
     resolution: {integrity: sha512-ImZ0sEMUQdKGSsz6d7vN7JwZEk+dPN7qGkcaRvh9EjkhX40uWgdjigGrNHMM8Liamy1rVclpfub4MC7J2Jvuxg==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^18 || >=19.0.0-0
+      react-dom: ^18 || >=19.0.0-0
+      react-is: ^18 || >=19.0.0-0
+      styled-components: ^5.2 || ^6
+
+  '@sanity/ui@3.3.5':
+    resolution: {integrity: sha512-xXsaquGfi93EHTuOgctH/ryu7J8fe9lajtsq6We1Opmnjr0bron7DOyAaMAUm1jSxemrVDnVJ6s/6TuagDZVEg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^18 || >=19.0.0-0
@@ -4373,12 +4424,21 @@ packages:
   '@sanity/uuid@3.0.2':
     resolution: {integrity: sha512-vzdhqOrX7JGbMyK40KuIwwyXHm7GMLOGuYgn3xlC09e4ZVNofUO5mgezQqnRv0JAMthIRhofqs9f6ufUjMKOvw==}
 
+  '@sanity/uuid@3.0.3':
+    resolution: {integrity: sha512-aJvKuFwzcZKRwuIjrRPfXfXKpSdnLF4CnedV5WcX1n5SzhufvRNHIot5lkx1+Y1DwiMVQOZ5gDSPJH+P6Ao70A==}
+
   '@sanity/vision@5.13.0':
     resolution: {integrity: sha512-kOVAReBYqW70j6alKRyKj1PKS2Jnzyym7J7FmeHON+xvS1ErfXOUI12hMPgt1Ga1ZU+hIP25i/KJ+PzQ4/Xueg==}
     peerDependencies:
       react: ^19.2.2
       sanity: ^4.0.0-0 || ^5.0.0-0
       styled-components: ^6.1.15
+
+  '@sanity/visual-editing-csm@3.0.11':
+    resolution: {integrity: sha512-biaPXe9Qqc7ybqTVEzsUFlL3aOZci+bUu+/TMTf05diz1Np1ZnFJXdLl1dhPjwmzzPVyycsu7aymNYg5ep6sWw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.23.0
 
   '@sanity/visual-editing-csm@3.0.5':
     resolution: {integrity: sha512-hhu1LUik3YtteIszYGL8si4L7DtR/VjHJj1jQZVa4rzdko7Fs7lnU1s/jT7/8EZ/NIBXe3oFBg98vyGc02J0JA==}
@@ -4396,6 +4456,16 @@ packages:
       '@sanity/types':
         optional: true
 
+  '@sanity/visual-editing-types@2.0.10':
+    resolution: {integrity: sha512-Vk82RsODvAoHfHJsvRp/RUI27WczkG+LhvSjxV5G4exBmJL9ZW9gsXetP38Zaof8NKq2VIqaNWcgBSZijowFRQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.23.0
+      '@sanity/types': '*'
+    peerDependenciesMeta:
+      '@sanity/types':
+        optional: true
+
   '@sanity/visual-editing-types@2.0.4':
     resolution: {integrity: sha512-X8R7lCb/0Cto2A++hNg6YuhBlg22iWffENFu5QKx+Gw8csFHuOF0Oboja1QLsWzMNGeHwJLl0WNhucxQqtyFlw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -4406,11 +4476,11 @@ packages:
       '@sanity/types':
         optional: true
 
-  '@sanity/visual-editing@5.3.0':
-    resolution: {integrity: sha512-FN8DslcXzKXDOI6B/aUSO8Z+20Rur3tDnUD9b10AoP87as/elWZL8IEkoVSd2aLKh6xJRQaUc/FDaF5eHR/sCw==}
+  '@sanity/visual-editing@5.6.0':
+    resolution: {integrity: sha512-GQmRjLzsyQt/MKNATwCev7+wibM1nqx43hYGBevgp3RSfr+N4GTqhn+qOVljccp8aTcDbfTHbOonPTTa/yTULA==}
     engines: {node: '>=20.19'}
     peerDependencies:
-      '@sanity/client': ^7.14.1
+      '@sanity/client': ^7.24.0
       '@sveltejs/kit': '>= 2'
       next: '>=16.0.0-0'
       react: ^19.2
@@ -5281,6 +5351,9 @@ packages:
 
   '@vercel/stega@1.0.0':
     resolution: {integrity: sha512-jyDUZEBjxmlh28J4y2wB6dBKayYOw1+9fRNRHWRN2oSO+LnooRHUe2z3JeTkCqXY2yrZ9dmtCl982YNIoIBeuw==}
+
+  '@vercel/stega@1.1.0':
+    resolution: {integrity: sha512-DFOm3Gk78nKDkppQEG5aj8Wj8R8hPKu/xrz4Rtp0AfiaNbZNCoJbxn7VI6iMxqhGeLdUDy/8mTuTWMz/izAtPA==}
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -7151,6 +7224,20 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@12.42.2:
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -8148,6 +8235,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
@@ -8494,8 +8584,14 @@ packages:
   motion-dom@12.35.1:
     resolution: {integrity: sha512-7n6r7TtNOsH2UFSAXzTkfzOeO5616v9B178qBIjmu/WgEyJK0uqwytCEhwKBTuM/HJA40ptAw7hLFpxtPAMRZQ==}
 
+  motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+
   motion-utils@12.29.2:
     resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   motion-v@1.10.3:
     resolution: {integrity: sha512-9Ewo/wwGv7FO3PqYJpllBF/Efc7tbeM1iinVrM73s0RUQrnXHwMZCaRX98u4lu0PQCrZghPPfCsQ14pWKIEbnQ==}
@@ -8505,6 +8601,20 @@ packages:
 
   motion@12.35.1:
     resolution: {integrity: sha512-yEt/49kWC0VU/IEduDfeZw82eDemlPwa1cyo/gcEEUCN4WgpSJpUcxz6BUwakGabvJiTzLQ58J73515I5tfykQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  motion@12.42.2:
+    resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -8549,6 +8659,11 @@ packages:
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanoid@5.1.6:
@@ -9666,6 +9781,9 @@ packages:
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-refractor@4.0.0:
     resolution: {integrity: sha512-2VMRH3HA/Nu+tMFzyQwdBK0my0BIZy1pkWHhjuSrplMyf8ZLx/Gw7tUXV0t2JbEsbSNHbEc9TbHhq3sUx2seVA==}
@@ -11574,6 +11692,9 @@ packages:
 
   xstate@5.28.0:
     resolution: {integrity: sha512-Iaqq6ZrUzqeUtA3hC5LQKZfR8ZLzEFTImMHJM3jWEdVvXWdKvvVLXZEiNQWm3SCA9ZbEou/n5rcsna1wb9t28A==}
+
+  xstate@5.32.5:
+    resolution: {integrity: sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -13630,6 +13751,8 @@ snapshots:
       minipass: 7.1.3
 
   '@isaacs/ttlcache@1.4.1': {}
+
+  '@isaacs/ttlcache@2.1.5': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -15826,7 +15949,7 @@ snapshots:
       '@inquirer/prompts': 8.3.0(@types/node@25.4.0)
       '@oclif/core': 4.8.2
       '@rexxars/jiti': 2.6.2
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       '@sanity/telemetry': 0.8.1(react@19.2.4)
       '@sanity/types': 5.13.0(@types/react@19.2.14)
       babel-plugin-react-compiler: 1.0.0
@@ -15871,7 +15994,7 @@ snapshots:
       '@inquirer/prompts': 8.3.0(@types/node@25.4.0)
       '@oclif/core': 4.8.2
       '@rexxars/jiti': 2.6.2
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       '@sanity/telemetry': 1.1.0(react@19.2.4)
       '@sanity/types': 5.13.0(@types/react@19.2.14)
       babel-plugin-react-compiler: 1.0.0
@@ -16064,20 +16187,20 @@ snapshots:
       uuid: 13.0.0
       xstate: 5.28.0
 
-  '@sanity/core-loader@2.0.6(@sanity/types@5.13.0(@types/react@19.2.14))(typescript@6.0.2)':
+  '@sanity/core-loader@2.0.6(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)':
     dependencies:
       '@sanity/client': 7.22.1
       '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))
-      '@sanity/visual-editing-csm': 3.0.5(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))(typescript@6.0.2)
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
+      '@sanity/visual-editing-csm': 3.0.5(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/debug-preview-url-secret-plugin@2.0.7(@sanity/client@7.22.1)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))':
+  '@sanity/debug-preview-url-secret-plugin@2.0.7(@sanity/client@7.24.0)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.22.1)
+      '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.24.0)
       react: 19.2.4
       sanity: 5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -16131,6 +16254,14 @@ snapshots:
   '@sanity/generate-help-url@4.0.0': {}
 
   '@sanity/icons@3.7.4(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@sanity/icons@3.8.0(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@sanity/icons@5.1.0(react@19.2.4)':
     dependencies:
       react: 19.2.4
 
@@ -16203,6 +16334,8 @@ snapshots:
 
   '@sanity/media-library-types@1.2.0': {}
 
+  '@sanity/media-library-types@1.6.0': {}
+
   '@sanity/message-protocol@0.12.0':
     dependencies:
       '@sanity/comlink': 2.0.5
@@ -16251,7 +16384,7 @@ snapshots:
 
   '@sanity/mutate@0.12.6':
     dependencies:
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
@@ -16262,7 +16395,7 @@ snapshots:
 
   '@sanity/mutate@0.16.1(xstate@5.28.0)':
     dependencies:
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
@@ -16272,6 +16405,20 @@ snapshots:
       rxjs: 7.8.2
     optionalDependencies:
       xstate: 5.28.0
+
+  '@sanity/mutate@0.18.1(xstate@5.32.5)':
+    dependencies:
+      '@isaacs/ttlcache': 2.1.5
+      '@sanity/client': 7.24.0
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/uuid': 3.0.2
+      hotscript: 1.0.13
+      lodash: 4.18.1
+      mendoza: 3.0.8
+      nanoid: 5.1.16
+      rxjs: 7.8.2
+    optionalDependencies:
+      xstate: 5.32.5
 
   '@sanity/mutator@5.13.0(@types/react@19.2.14)':
     dependencies:
@@ -16292,10 +16439,36 @@ snapshots:
       - '@sanity/client'
       - '@sanity/types'
 
+  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))':
+    dependencies:
+      '@sanity/comlink': 4.0.1
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
+    transitivePeerDependencies:
+      - '@sanity/client'
+      - '@sanity/types'
+
+  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))':
+    dependencies:
+      '@sanity/comlink': 4.0.1
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
+    transitivePeerDependencies:
+      - '@sanity/client'
+      - '@sanity/types'
+
   '@sanity/preview-url-secret@4.0.3(@sanity/client@7.22.1)':
     dependencies:
       '@sanity/client': 7.22.1
       '@sanity/uuid': 3.0.2
+
+  '@sanity/preview-url-secret@4.0.3(@sanity/client@7.24.0)':
+    dependencies:
+      '@sanity/client': 7.24.0
+      '@sanity/uuid': 3.0.2
+
+  '@sanity/preview-url-secret@4.1.0(@sanity/client@7.22.1)':
+    dependencies:
+      '@sanity/client': 7.22.1
+      '@sanity/uuid': 3.0.3
 
   '@sanity/runtime-cli@14.4.0(@types/node@25.4.0)(lightningcss@1.31.1)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
@@ -16306,7 +16479,7 @@ snapshots:
       '@oclif/plugin-help': 6.2.37
       '@sanity/blueprints': 0.13.1
       '@sanity/blueprints-parser': 0.4.0
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       adm-zip: 0.5.16
       array-treeify: 0.1.5
       cardinal: 2.1.1
@@ -16403,7 +16576,7 @@ snapshots:
 
   '@sanity/types@3.99.0(@types/react@19.2.14)':
     dependencies:
-      '@sanity/client': 7.22.1
+      '@sanity/client': 7.24.0
       '@sanity/media-library-types': 1.2.0
       '@types/react': 19.2.14
 
@@ -16411,6 +16584,12 @@ snapshots:
     dependencies:
       '@sanity/client': 7.22.1
       '@sanity/media-library-types': 1.2.0
+      '@types/react': 19.2.14
+
+  '@sanity/types@6.5.0(@types/react@19.2.14)':
+    dependencies:
+      '@sanity/client': 7.24.0
+      '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.14
 
   '@sanity/ui@3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
@@ -16425,6 +16604,42 @@ snapshots:
       react-compiler-runtime: 1.0.0(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
       react-is: 19.2.4
+      react-refractor: 4.0.0(react@19.2.4)
+      styled-components: 6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      use-effect-event: 2.0.3(react@19.2.4)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+
+  '@sanity/ui@3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@juggle/resize-observer': 3.4.0
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.7.4(react@19.2.4)
+      csstype: 3.2.3
+      motion: 12.35.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-compiler-runtime: 1.0.0(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.7
+      react-refractor: 4.0.0(react@19.2.4)
+      styled-components: 6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      use-effect-event: 2.0.3(react@19.2.4)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+
+  '@sanity/ui@3.3.5(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@juggle/resize-observer': 3.4.0
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.8.0(react@19.2.4)
+      csstype: 3.2.3
+      motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-compiler-runtime: 1.0.0(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.7
       react-refractor: 4.0.0(react@19.2.4)
       styled-components: 6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       use-effect-event: 2.0.3(react@19.2.4)
@@ -16447,7 +16662,11 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vision@5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/uuid@3.0.3':
+    dependencies:
+      uuid: 11.1.0
+
+  '@sanity/vision@5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.2)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(sanity@5.13.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.4.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.7.0)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.3
@@ -16461,7 +16680,7 @@ snapshots:
       '@rexxars/react-split-pane': 1.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/uuid': 3.0.2
       '@uiw/react-codemirror': 4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.2)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       is-hotkey-esm: 1.0.0
@@ -16483,10 +16702,19 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/visual-editing-csm@3.0.5(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))(typescript@6.0.2)':
+  '@sanity/visual-editing-csm@3.0.11(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)':
     dependencies:
       '@sanity/client': 7.22.1
-      '@sanity/visual-editing-types': 2.0.4(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))
+      '@sanity/visual-editing-types': 2.0.10(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
+      valibot: 1.4.1(typescript@6.0.2)
+    transitivePeerDependencies:
+      - '@sanity/types'
+      - typescript
+
+  '@sanity/visual-editing-csm@3.0.5(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)':
+    dependencies:
+      '@sanity/client': 7.22.1
+      '@sanity/visual-editing-types': 2.0.4(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
       valibot: 1.4.1(typescript@6.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
@@ -16498,36 +16726,49 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 5.13.0(@types/react@19.2.14)
 
-  '@sanity/visual-editing-types@2.0.4(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))':
     dependencies:
       '@sanity/client': 7.22.1
     optionalDependencies:
-      '@sanity/types': 5.13.0(@types/react@19.2.14)
+      '@sanity/types': 6.5.0(@types/react@19.2.14)
 
-  '@sanity/visual-editing@5.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)':
+  '@sanity/visual-editing-types@2.0.10(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))':
+    dependencies:
+      '@sanity/client': 7.22.1
+    optionalDependencies:
+      '@sanity/types': 6.5.0(@types/react@19.2.14)
+
+  '@sanity/visual-editing-types@2.0.4(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))':
+    dependencies:
+      '@sanity/client': 7.22.1
+    optionalDependencies:
+      '@sanity/types': 6.5.0(@types/react@19.2.14)
+
+  '@sanity/visual-editing@5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.22.1)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/insert-menu': 3.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.13.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@sanity/mutate': 0.16.1(xstate@5.28.0)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))
-      '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.22.1)
-      '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@sanity/visual-editing-csm': 3.0.5(@sanity/client@7.22.1)(@sanity/types@5.13.0(@types/react@19.2.14))(typescript@6.0.2)
-      '@vercel/stega': 1.0.0
+      '@sanity/icons': 5.1.0(react@19.2.4)
+      '@sanity/mutate': 0.18.1(xstate@5.32.5)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))
+      '@sanity/preview-url-secret': 4.1.0(@sanity/client@7.22.1)
+      '@sanity/types': 6.5.0(@types/react@19.2.14)
+      '@sanity/ui': 3.3.5(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.7)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/visual-editing-csm': 3.0.11(@sanity/client@7.22.1)(@sanity/types@6.5.0(@types/react@19.2.14))(typescript@6.0.2)
+      '@vercel/stega': 1.1.0
       dequal: 2.0.3
+      lodash-es: 4.18.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.7
       rxjs: 7.8.2
       scroll-into-view-if-needed: 3.1.0
       styled-components: 6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      xstate: 5.28.0
+      xstate: 5.32.5
     optionalDependencies:
       '@sanity/client': 7.22.1
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
-      - '@sanity/types'
-      - react-is
+      - '@types/react'
       - typescript
 
   '@sanity/worker-channels@1.1.0': {}
@@ -17420,6 +17661,8 @@ snapshots:
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/stega@1.0.0': {}
+
+  '@vercel/stega@1.1.0': {}
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.5(@types/node@25.4.0)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -19668,6 +19911,16 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  framer-motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
@@ -20792,6 +21045,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@2.2.0:
     dependencies:
       chalk: 2.4.2
@@ -21321,7 +21576,13 @@ snapshots:
     dependencies:
       motion-utils: 12.29.2
 
+  motion-dom@12.42.2:
+    dependencies:
+      motion-utils: 12.39.0
+
   motion-utils@12.29.2: {}
+
+  motion-utils@12.39.0: {}
 
   motion-v@1.10.3(@emotion/is-prop-valid@1.4.0)(@vueuse/core@14.2.1(vue@3.5.35(typescript@6.0.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vue@3.5.35(typescript@6.0.2)):
     dependencies:
@@ -21338,6 +21599,15 @@ snapshots:
   motion@12.35.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       framer-motion: 12.35.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  motion@12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.4.0
@@ -21361,6 +21631,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   nanoid@3.3.16: {}
+
+  nanoid@5.1.16: {}
 
   nanoid@5.1.6: {}
 
@@ -22991,6 +23263,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@19.2.4: {}
+
+  react-is@19.2.7: {}
 
   react-refractor@4.0.0(react@19.2.4):
     dependencies:
@@ -25266,6 +25540,8 @@ snapshots:
     optional: true
 
   xstate@5.28.0: {}
+
+  xstate@5.32.5: {}
 
   xtend@4.0.2: {}
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,7 +28,7 @@ import { genExport } from 'knitwork'
 
 import { findQueriesInSource } from '@sanity/codegen'
 import type { ClientConfig as SanityClientConfig, StegaConfig } from '@sanity/client'
-import type { HistoryRefresh } from '@sanity/visual-editing'
+import type { HistoryRefresh, SuspiciousStegaReport } from '@sanity/visual-editing'
 import { normalizeQuery } from './runtime/util/normalizeQuery'
 import { name, version } from '../package.json'
 
@@ -43,6 +43,10 @@ export type SanityVisualEditingRefreshHandler = (
   payload: HistoryRefresh,
   refreshDefault: () => false | Promise<void>,
 ) => false | Promise<void>
+
+export type SanityVisualEditingOnSuspiciousStega = (
+  reports: SuspiciousStegaReport[],
+) => void
 
 export interface SanityModuleVisualEditingOptions {
   /**
@@ -79,11 +83,27 @@ export interface SanityModuleVisualEditingOptions {
    */
   stega?: boolean
   /**
+   * While visual editing is enabled, stega-encoded metadata (invisible
+   * characters) is automatically stripped from clipboard data when content is
+   * copied from the page. Set this option to `true` to opt out and keep stega
+   * in copied content.
+   * @default false
+   */
+  keepStegaOnCopy?: boolean
+  /**
    * An optional function for overriding the default handling of refresh events
    * received from the studio. This is generally not need needed if the `mode`
    * option is set to `live-visual-editing`.
    */
   refresh?: SanityVisualEditingRefreshHandler
+  /**
+   * An optional callback that reports stega payloads found in places where
+   * they always cause bugs or bloat, such as `class`, `href`, `src`, `id` and
+   * other attributes, inside `<head>`, `<script>` or `<style>` contents, form
+   * values, or the page URL. Providing the callback opts in to the detection
+   * logic — when it isn't provided no scanning runs.
+   */
+  onSuspiciousStega?: SanityVisualEditingOnSuspiciousStega
   /**
    * The CSS z-index on the root node that renders overlays
    * @default 9999999
@@ -283,6 +303,7 @@ export default defineNuxtModule<SanityModuleOptions>({
       }
 
       publicRuntimeConfig.visualEditing = {
+        keepStegaOnCopy: options.visualEditing.keepStegaOnCopy ?? false,
         mode: options.visualEditing.mode || 'live-visual-editing',
         previewMode,
         previewModeId: '',
@@ -634,6 +655,7 @@ export default defineNuxtModule<SanityModuleOptions>({
         filename: 'sanity-visual-editing-refresh.mjs',
         getContents: () => `
             export const sanityVisualEditingRefresh = ${options.visualEditing?.refresh?.toString() || 'undefined'}
+            export const sanityVisualEditingOnSuspiciousStega = ${options.visualEditing?.onSuspiciousStega?.toString() || 'undefined'}
           `,
         write: true,
       })
@@ -642,6 +664,7 @@ export default defineNuxtModule<SanityModuleOptions>({
       addImports([
         { name: 'createDataAttribute', from: '@sanity/visual-editing', as: 'createSanityDataAttribute' },
         { name: 'sanityVisualEditingRefresh', from: '#build/sanity-visual-editing-refresh.mjs' },
+        { name: 'sanityVisualEditingOnSuspiciousStega', from: '#build/sanity-visual-editing-refresh.mjs' },
         { name: 'useSanityLiveMode', from: join(runtimeDir, 'composables/useSanityLiveMode') },
         { name: 'useSanityVisualEditing', from: join(runtimeDir, 'composables/useSanityVisualEditing') },
       ])

--- a/src/runtime/composables/useSanityVisualEditing.ts
+++ b/src/runtime/composables/useSanityVisualEditing.ts
@@ -10,13 +10,15 @@ export function useSanityVisualEditing(options: VisualEditingProps = {}) {
     throw new Error('Configure the `sanity.visualEditing` property in your `nuxt.config.ts` to use the `useSanityVisualEditing` composable. ')
   }
 
-  const { zIndex, refresh } = options
+  const { keepStegaOnCopy, onSuspiciousStega, zIndex, refresh } = options
 
   let disable = () => {}
 
   if (import.meta.client) {
     const router = useRouter()
     disable = enableVisualEditing({
+      keepStegaOnCopy,
+      onSuspiciousStega,
       zIndex,
       // It is unlikely this API will be used as much by Nuxt users, as
       // implementing fully fledged visual editing is more straightforward

--- a/src/runtime/plugins/visual-editing.client.ts
+++ b/src/runtime/plugins/visual-editing.client.ts
@@ -1,5 +1,5 @@
 import { defineNuxtPlugin } from '#imports'
-import { sanityVisualEditingRefresh } from '#build/sanity-visual-editing-refresh.mjs'
+import { sanityVisualEditingOnSuspiciousStega, sanityVisualEditingRefresh } from '#build/sanity-visual-editing-refresh.mjs'
 import { useSanityConfig } from '../composables/useSanityConfig'
 import { useSanityVisualEditingState } from '../composables/useSanityVisualEditingState'
 import { useSanityVisualEditing } from '../composables/useSanityVisualEditing'
@@ -17,6 +17,8 @@ export default defineNuxtPlugin(async () => {
     || visualEditing.mode === 'visual-editing'
   ) {
     useSanityVisualEditing({
+      keepStegaOnCopy: visualEditing.keepStegaOnCopy || undefined,
+      onSuspiciousStega: sanityVisualEditingOnSuspiciousStega,
       refresh: sanityVisualEditingRefresh,
       zIndex: visualEditing.zIndex || undefined,
     })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import type { HistoryRefresh, VisualEditingOptions } from '@sanity/visual-editing'
+import type { HistoryRefresh, SuspiciousStegaReport, VisualEditingOptions } from '@sanity/visual-editing'
 import type { QueryStore } from '@sanity/core-loader'
 import type { AsyncDataOptions } from 'nuxt/app'
 import type { ClientPerspective, ContentSourceMap, StegaConfig } from '@sanity/client'
@@ -131,6 +131,8 @@ export interface UseSanityQueryOptions<T> extends AsyncDataOptions<T> {
  * @internal
  */
 export interface VisualEditingProps {
+  keepStegaOnCopy?: boolean
+  onSuspiciousStega?: SanityVisualEditingOnSuspiciousStega
   refresh?: SanityVisualEditingRefreshHandler
   zIndex?: SanityVisualEditingZIndex
 }
@@ -149,6 +151,15 @@ export type SanityVisualEditingRefreshHandler = (
   payload: HistoryRefresh,
   refreshDefault: () => false | Promise<void>,
 ) => false | Promise<void>
+
+/**
+ * Handler function for reports of stega payloads found in places where they
+ * always cause bugs or bloat
+ * @public
+ */
+export type SanityVisualEditingOnSuspiciousStega = (
+  reports: SuspiciousStegaReport[],
+) => void
 
 export type SanityRuntimeConfig = {
   liveContent?:
@@ -184,6 +195,7 @@ export type SanityPublicRuntimeConfig = {
   useCdn: boolean
   visualEditing?:
   | {
+    keepStegaOnCopy: boolean
     mode: SanityVisualEditingMode
     previewMode:
       | false
@@ -216,6 +228,7 @@ export type SanityResolvedConfig
       visualEditing:
         | null
         | {
+          keepStegaOnCopy: boolean
           mode: SanityVisualEditingMode
           previewMode:
             | boolean
@@ -232,6 +245,13 @@ export type SanityResolvedConfig
     }
 
 export type SanityVisualEditingZIndex = VisualEditingOptions['zIndex']
+
+/**
+ * Re-export of the `SuspiciousStegaReport` type from `@sanity/visual-editing`,
+ * describing the reports passed to an `onSuspiciousStega` handler
+ * @public
+ */
+export type { SuspiciousStegaReport } from '@sanity/visual-editing'
 
 export type SanityGroqQueryArray = Array<{ filepath: string, queries: string[] }>
 

--- a/src/runtime/virtual-modules.d.ts
+++ b/src/runtime/virtual-modules.d.ts
@@ -2,7 +2,8 @@
 // These stubs are used for type checking source files before Nuxt app preparation
 
 declare module '#build/sanity-visual-editing-refresh.mjs' {
-  import type { SanityVisualEditingRefreshHandler } from '@nuxtjs/sanity'
+  import type { SanityVisualEditingOnSuspiciousStega, SanityVisualEditingRefreshHandler } from '@nuxtjs/sanity'
 
   export const sanityVisualEditingRefresh: SanityVisualEditingRefreshHandler | undefined
+  export const sanityVisualEditingOnSuspiciousStega: SanityVisualEditingOnSuspiciousStega | undefined
 }


### PR DESCRIPTION
## Summary

- Bumps `@sanity/visual-editing` to `^5.6.0`, which includes [sanity-io/visual-editing#3492](https://github.com/sanity-io/visual-editing/pull/3492): stega is now automatically stripped from clipboard data on copy while visual editing is enabled, and an opt-in reporting API can flag stega payloads in places where they always cause bugs or bloat.
- Exposes the two new options through both configuration paths:
  - `keepStegaOnCopy` (boolean, serializable) flows through public runtime config like `zIndex`, so copy-stripping can be opted out of via `sanity.visualEditing` in `nuxt.config.ts`.
  - `onSuspiciousStega` (function) is inlined via the same build template mechanism as `refresh`, and both are also accepted as props on `useSanityVisualEditing()` for `custom` mode.
- Re-exports the `SuspiciousStegaReport` type and adds a `SanityVisualEditingOnSuspiciousStega` handler type, and documents both options on the visual editing docs page.

## Note on future direction

Sanity is working on a new [`@sanity/visual-editing-standalone`](https://github.com/sanity-io/visual-editing/pull/3510) package that only exposes `enableVisualEditing` and `createDataAttribute`, inlines the full browser runtime with zero production/peer dependencies, and ships framework-neutral type declarations. That will be much easier for libraries like this Nuxt module to consume — for example, the react/styled-components `optimizeDeps` workarounds in `src/module.ts` would no longer be needed. This PR sticks with `@sanity/visual-editing` for now; migrating to the standalone package is a natural follow-up once it ships.

## Test plan

- [x] `pnpm test:unit` (60 tests pass)
- [x] `pnpm test:types` (vue-tsc)
- [x] `pnpm lint`
- [x] `pnpm build` — verified the new options and types appear in `dist/module.d.mts`, `dist/runtime/types.d.ts` and the runtime plugin/composable output

Made with [Cursor](https://cursor.com)