### PR TITLE
feat: make `previewCookieName` configurable and add `useSanityPreviewCookie`

### DIFF
--- a/docs/content/1.getting-started/5.visual-editing.md
+++ b/docs/content/1.getting-started/5.visual-editing.md
@@ -56,6 +56,24 @@ To enable preview mode with defaults, or optionally configure the endpoints used
 - `enable` - the path of the enable endpoint, defaults to `/preview/enable`
 - `disable` - the path of the disable endpoint, defaults to `/preview/disable`
 
+#### `previewCookieName`
+
+- Type: **string**
+- Default: **`'sanity-preview-id'`**
+
+The name of the cookie used to store the preview mode ID. Set this if the default cookie name conflicts with another cookie used in your app, or if you want to read the cookie yourself — for example to protect routes when preview mode is not active.
+
+The cookie is `httpOnly`, so its value can only be read on the server. You can read it with the `useSanityPreviewCookie` composable, for example in a Nuxt route middleware:
+
+```ts{}[middleware/preview.ts]
+export default defineNuxtRouteMiddleware(() => {
+  const previewCookie = useSanityPreviewCookie()
+  if (!previewCookie.value) {
+    return navigateTo('/login')
+  }
+})
+```
+
 #### `stega`
 
 - Type: **boolean**

--- a/src/module.ts
+++ b/src/module.ts
@@ -30,6 +30,7 @@ import { findQueriesInSource } from '@sanity/codegen'
 import type { ClientConfig as SanityClientConfig, StegaConfig } from '@sanity/client'
 import type { HistoryRefresh, SuspiciousStegaReport } from '@sanity/visual-editing-standalone'
 import { normalizeQuery } from './runtime/util/normalizeQuery'
+import { previewCookieName as defaultPreviewCookieName } from './runtime/constants'
 import { name, version } from '../package.json'
 
 import type { ClientConfig as MinimalClientConfig } from './runtime/minimal-client'
@@ -58,6 +59,12 @@ export interface SanityModuleVisualEditingOptions {
       enable?: string
       disable?: string
     }
+  /**
+   * The name of the cookie used to store the preview mode ID. Useful if the
+   * default cookie name conflicts with another cookie used in your app.
+   * @default 'sanity-preview-id'
+   */
+  previewCookieName?: string
   /**
    * Enable visual editing at app level or per component
    * @default 'live-visual-editing'
@@ -305,6 +312,7 @@ export default defineNuxtModule<SanityModuleOptions>({
       publicRuntimeConfig.visualEditing = {
         keepStegaOnCopy: options.visualEditing.keepStegaOnCopy ?? false,
         mode: options.visualEditing.mode || 'live-visual-editing',
+        previewCookieName: options.visualEditing.previewCookieName || defaultPreviewCookieName,
         previewMode,
         previewModeId: '',
         proxyEndpoint: options.visualEditing.proxyEndpoint || '/_sanity/visual-editing/fetch',
@@ -514,6 +522,7 @@ export default defineNuxtModule<SanityModuleOptions>({
 
         const visualEditingExports = publicRuntimeConfig.visualEditing
           ? [
+              `export { useSanityPreviewCookie } from '${join(runtimeDir, 'composables/useSanityPreviewCookie')}'`,
               `export { useSanityVisualEditing } from '${join(runtimeDir, 'composables/useSanityVisualEditing')}'`,
               `export { useSanityLiveMode } from '${join(runtimeDir, 'composables/useSanityLiveMode')}'`,
             ]
@@ -651,6 +660,7 @@ export default defineNuxtModule<SanityModuleOptions>({
         { name: 'sanityVisualEditingRefresh', from: '#build/sanity-visual-editing-refresh.mjs' },
         { name: 'sanityVisualEditingOnSuspiciousStega', from: '#build/sanity-visual-editing-refresh.mjs' },
         { name: 'useSanityLiveMode', from: join(runtimeDir, 'composables/useSanityLiveMode') },
+        { name: 'useSanityPreviewCookie', from: join(runtimeDir, 'composables/useSanityPreviewCookie') },
         { name: 'useSanityVisualEditing', from: join(runtimeDir, 'composables/useSanityVisualEditing') },
       ])
 

--- a/src/runtime/composables/useSanityPreviewCookie.ts
+++ b/src/runtime/composables/useSanityPreviewCookie.ts
@@ -1,0 +1,15 @@
+import { previewCookieName } from '../constants'
+import { useSanityConfig } from './useSanityConfig'
+import { useCookie } from '#imports'
+
+/**
+ * Returns the preview mode cookie. The cookie is `httpOnly`, so its value can
+ * only be read on the server — for example in server routes or during
+ * server-side rendering, such as in route middleware — which can be useful to
+ * protect routes when preview mode is not active.
+ * @public
+ */
+export const useSanityPreviewCookie = () => {
+  const { visualEditing } = useSanityConfig()
+  return useCookie(visualEditing?.previewCookieName ?? previewCookieName)
+}

--- a/src/runtime/plugins/visual-editing.server.ts
+++ b/src/runtime/plugins/visual-editing.server.ts
@@ -16,7 +16,7 @@ export default defineNuxtPlugin(() => {
   // check the cookie value against `previewModeId` to determine if visual
   // editing is enabled.
   if (previewMode) {
-    const previewModeCookie = useCookie(previewCookieName)
+    const previewModeCookie = useCookie(visualEditing?.previewCookieName ?? previewCookieName)
     visualEditingState.enabled = previewModeCookie.value === previewModeId
   // If preview mode is _not_ configured, just enable visual editing.
   }

--- a/src/runtime/server/routes/preview/disable.ts
+++ b/src/runtime/server/routes/preview/disable.ts
@@ -1,8 +1,10 @@
 import { defineEventHandler, deleteCookie, getQuery, sendRedirect } from 'h3'
 import { previewCookieName } from '../../../constants'
+import { useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const { redirect } = getQuery(event)
-  deleteCookie(event, previewCookieName)
+  const $config = useRuntimeConfig(event)
+  deleteCookie(event, $config.public.sanity.visualEditing?.previewCookieName ?? previewCookieName)
   await sendRedirect(event, redirect?.toString() || '/')
 })

--- a/src/runtime/server/routes/preview/enable.ts
+++ b/src/runtime/server/routes/preview/enable.ts
@@ -30,7 +30,11 @@ export default defineEventHandler(async (event) => {
     ? sanityConfig.visualEditing.previewModeId
     : undefined as never
 
-  setCookie(event, previewCookieName, id, {
+  const cookieName = sanityConfig.visualEditing && 'previewCookieName' in sanityConfig.visualEditing
+    ? sanityConfig.visualEditing.previewCookieName
+    : previewCookieName
+
+  setCookie(event, cookieName, id, {
     httpOnly: true,
     sameSite: !import.meta.dev ? 'none' : 'lax',
     secure: !import.meta.dev,

--- a/src/runtime/server/routes/preview/proxy.ts
+++ b/src/runtime/server/routes/preview/proxy.ts
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event) => {
   const { liveContent, visualEditing } = $config.sanity
 
   const { query, params = {}, options } = await readBody(event)
-  const previewModeCookie = getCookie(event, previewCookieName)
+  const previewModeCookie = getCookie(event, $config.public.sanity.visualEditing?.previewCookieName ?? previewCookieName)
 
   const token = visualEditing?.token || liveContent?.serverToken
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -197,6 +197,7 @@ export type SanityPublicRuntimeConfig = {
   | {
     keepStegaOnCopy: boolean
     mode: SanityVisualEditingMode
+    previewCookieName: string
     previewMode:
       | false
       | {
@@ -230,6 +231,7 @@ export type SanityResolvedConfig
         | {
           keepStegaOnCopy: boolean
           mode: SanityVisualEditingMode
+          previewCookieName: string
           previewMode:
             | boolean
             | {

--- a/test/unit/useSanityPreviewCookie.test.ts
+++ b/test/unit/useSanityPreviewCookie.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+import { useSanityPreviewCookie } from '../../src/runtime/composables/useSanityPreviewCookie'
+
+const mocks = vi.hoisted(() => ({
+  useCookie: vi.fn(),
+  runtimeConfig: { value: {} as Record<string, any> },
+}))
+
+vi.mock('#imports', () => ({
+  useCookie: mocks.useCookie,
+  useRuntimeConfig: () => mocks.runtimeConfig.value,
+}))
+
+const publicSanity = (visualEditing?: Record<string, unknown>) => ({
+  public: {
+    sanity: {
+      ...visualEditing ? { visualEditing } : {},
+    },
+  },
+})
+
+describe('useSanityPreviewCookie', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the default preview cookie name when not configured', () => {
+    mocks.runtimeConfig.value = publicSanity()
+    mocks.useCookie.mockReturnValue(ref('preview-id'))
+
+    const cookie = useSanityPreviewCookie()
+
+    expect(mocks.useCookie).toHaveBeenCalledWith('sanity-preview-id')
+    expect(cookie.value).toBe('preview-id')
+  })
+
+  it('uses the configured preview cookie name', () => {
+    mocks.runtimeConfig.value = publicSanity({ previewCookieName: 'my-custom-preview-cookie' })
+    mocks.useCookie.mockReturnValue(ref('preview-id'))
+
+    const cookie = useSanityPreviewCookie()
+
+    expect(mocks.useCookie).toHaveBeenCalledWith('my-custom-preview-cookie')
+    expect(cookie.value).toBe('preview-id')
+  })
+
+  it('returns the cookie ref returned by useCookie', () => {
+    mocks.runtimeConfig.value = publicSanity()
+    const cookieRef = ref<string | null>(null)
+    mocks.useCookie.mockReturnValue(cookieRef)
+
+    const cookie = useSanityPreviewCookie()
+
+    expect(cookie).toBe(cookieRef)
+    cookieRef.value = 'preview-id'
+    expect(cookie.value).toBe('preview-id')
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #1431. Makes the preview mode cookie name configurable via a new `visualEditing.previewCookieName` option, and adds a `useSanityPreviewCookie` composable so apps can read the cookie (e.g. to protect routes when preview mode is not active).

## Changes

- **`visualEditing.previewCookieName`** option (default `sanity-preview-id`) is threaded through the public runtime config, mirroring the existing `keepStegaOnCopy` option.
- All preview cookie consumers now use the configured name with a fallback to the default constant:
  - `server/routes/preview/enable.ts`
  - `server/routes/preview/disable.ts`
  - `server/routes/preview/proxy.ts`
  - `plugins/visual-editing.server.ts`
- New **`useSanityPreviewCookie`** composable reads the cookie value via `useSanityConfig()`; auto-imported and exported from the composables barrel when visual editing is configured.
- Types updated in `SanityPublicRuntimeConfig` and `SanityResolvedConfig`.
- Docs added for the option + composable in the visual editing guide.

## Tests

- New `test/unit/useSanityPreviewCookie.test.ts` covering:
  - default cookie name when not configured
  - configured cookie name
  - returned ref passthrough
- Full suite green: `176` tests across unit/e2e/nuxt projects, plus `test:types` and `lint`.

## Notes

The cookie is `httpOnly`, so `useSanityPreviewCookie` reads server-side (SSR/middleware), which is where route protection happens. The issue author's suggested `usePreviewCookie()` naming was adapted to `useSanityPreviewCookie` to match the module's composable conventions.